### PR TITLE
Add functionality to viewmodels

### DIFF
--- a/app/controllers/UnloadingPermissionController.scala
+++ b/app/controllers/UnloadingPermissionController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import javax.inject.Inject
 import models.PermissionToStartUnloading
 import play.api.Logger

--- a/app/json/package.scala
+++ b/app/json/package.scala
@@ -14,25 +14,29 @@
  * limitations under the License.
  */
 
-package viewmodels
-
 import cats.data.NonEmptyList
-import models.DeclarationType
-import models.reference.Country
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
 
-final case class GoodsItem(
-  itemNumber: Int,
-  commodityCode: Option[String],
-  declarationType: Option[DeclarationType],
-  description: String,
-  grossMass: Option[BigDecimal],
-  netMass: Option[BigDecimal],
-  countryOfDispatch: Country,
-  countryOfDestination: Country,
-  producedDocuments: Seq[ProducedDocument],
-  specialMentions: Seq[SpecialMention],
-  consignor: Option[Consignor],
-  consignee: Option[Consignee],
-  containers: Seq[String],
-  packages: NonEmptyList[Package]
-)
+package object json {
+
+  implicit object NonEmptyListOps {
+
+    implicit def reads[A: Reads]: Reads[NonEmptyList[A]] =
+      Reads
+        .of[List[A]]
+        .collect(
+          JsonValidationError("expected a NonEmptyList but the list was empty")
+        ) {
+          case head :: tail => NonEmptyList(head, tail)
+        }
+
+    implicit def writes[A: Writes]: Writes[NonEmptyList[A]] =
+      Writes
+        .of[List[A]]
+        .contramap(_.toList)
+
+    implicit def format[A: Format]: Format[NonEmptyList[A]] =
+      Format(reads, writes)
+  }
+}

--- a/app/models/GoodsItem.scala
+++ b/app/models/GoodsItem.scala
@@ -16,8 +16,10 @@
 
 package models
 
+import cats.data.NonEmptyList
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
+import json.NonEmptyListOps._
 
 final case class GoodsItem(
   itemNumber: Int,
@@ -33,7 +35,7 @@ final case class GoodsItem(
   consignor: Option[Consignor],
   consignee: Option[Consignee],
   containers: Seq[String],
-  packages: Seq[Package]
+  packages: NonEmptyList[Package]
 )
 
 object GoodsItem {

--- a/app/models/UnloadingPermission.scala
+++ b/app/models/UnloadingPermission.scala
@@ -18,7 +18,9 @@ package models
 
 import java.time.LocalDate
 
+import cats.data.NonEmptyList
 import play.api.libs.json._
+import json.NonEmptyListOps._
 
 sealed trait UnloadingPermission
 
@@ -58,7 +60,7 @@ final case class PermissionToStartUnloading(
   traderAtDestination: TraderAtDestination,
   presentationOffice: String,
   seals: Seq[String],
-  goodsItems: Seq[GoodsItem]
+  goodsItems: NonEmptyList[GoodsItem]
 ) extends UnloadingPermission
 
 object PermissionToStartUnloading {

--- a/app/viewmodels/PermissionToStartUnloading.scala
+++ b/app/viewmodels/PermissionToStartUnloading.scala
@@ -18,6 +18,7 @@ package viewmodels
 
 import java.time.LocalDate
 
+import cats.data.NonEmptyList
 import models.DeclarationType
 import models.reference.Country
 
@@ -34,7 +35,7 @@ final case class PermissionToStartUnloading(
   traderAtDestination: TraderAtDestination,
   presentationOffice: String,
   seals: Seq[String],
-  goodsItems: Seq[GoodsItem]
+  goodsItems: NonEmptyList[GoodsItem]
 ) {
 
   private def singleValue[A](items: Seq[A]): Option[A] =
@@ -45,16 +46,16 @@ final case class PermissionToStartUnloading(
     }
 
   val consignor: Option[Consignor] =
-    singleValue(goodsItems.flatMap(_.consignor))
+    singleValue(goodsItems.toList.flatMap(_.consignor))
 
   val consignee: Option[Consignee] =
-    singleValue(goodsItems.flatMap(_.consignee))
+    singleValue(goodsItems.toList.flatMap(_.consignee))
 
   val countryOfDispatch: Option[Country] =
-    singleValue(goodsItems.map(_.countryOfDispatch))
+    singleValue(goodsItems.toList.map(_.countryOfDispatch))
 
   val countryOfDestination: Option[Country] =
-    singleValue(goodsItems.map(_.countryOfDestination))
+    singleValue(goodsItems.toList.map(_.countryOfDestination))
 
   val printListOfItems: Boolean =
     goodsItems.size > 1 ||
@@ -66,10 +67,10 @@ final case class PermissionToStartUnloading(
   val printVariousConsignees: Boolean =
     printListOfItems &&
       consignee.isEmpty &&
-      goodsItems.flatMap(_.consignee).nonEmpty
+      goodsItems.toList.flatMap(_.consignee).nonEmpty
 
   val printVariousConsignors: Boolean =
     printListOfItems &&
       consignor.isEmpty &&
-      goodsItems.flatMap(_.consignor).nonEmpty
+      goodsItems.toList.flatMap(_.consignor).nonEmpty
 }

--- a/app/viewmodels/PermissionToStartUnloading.scala
+++ b/app/viewmodels/PermissionToStartUnloading.scala
@@ -35,4 +35,41 @@ final case class PermissionToStartUnloading(
   presentationOffice: String,
   seals: Seq[String],
   goodsItems: Seq[GoodsItem]
-)
+) {
+
+  private def singleValue[A](items: Seq[A]): Option[A] =
+    if (items.distinct.size == 1 && items.size == goodsItems.size) {
+      Some(items.head)
+    } else {
+      None
+    }
+
+  val consignor: Option[Consignor] =
+    singleValue(goodsItems.flatMap(_.consignor))
+
+  val consignee: Option[Consignee] =
+    singleValue(goodsItems.flatMap(_.consignee))
+
+  val countryOfDispatch: Option[Country] =
+    singleValue(goodsItems.map(_.countryOfDispatch))
+
+  val countryOfDestination: Option[Country] =
+    singleValue(goodsItems.map(_.countryOfDestination))
+
+  val printListOfItems: Boolean =
+    goodsItems.size > 1 ||
+      goodsItems.head.containers.size > 1 ||
+      goodsItems.head.packages.size > 1 ||
+      goodsItems.head.specialMentions.size > 4 ||
+      goodsItems.head.producedDocuments.size > 4
+
+  val printVariousConsignees: Boolean =
+    printListOfItems &&
+      consignee.isEmpty &&
+      goodsItems.flatMap(_.consignee).nonEmpty
+
+  val printVariousConsignors: Boolean =
+    printListOfItems &&
+      consignor.isEmpty &&
+      goodsItems.flatMap(_.consignor).nonEmpty
+}

--- a/test/controllers/UnloadingPermissionControllerSpec.scala
+++ b/test/controllers/UnloadingPermissionControllerSpec.scala
@@ -20,6 +20,7 @@ import java.time.LocalDate
 
 import cats.data.Chain
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.implicits._
 import cats.data.Validated.Invalid
 import cats.data.Validated.Valid
@@ -63,7 +64,7 @@ class UnloadingPermissionControllerSpec extends FreeSpec with MustMatchers with 
     traderAtDestination = models.TraderAtDestinationWithEori("Trader EORI", None, None, None, None, None),
     presentationOffice = "Presentation office",
     seals = Seq("seal 1"),
-    goodsItems = Seq(
+    goodsItems = NonEmptyList.one(
       models.GoodsItem(
         itemNumber = 1,
         commodityCode = None,
@@ -82,8 +83,9 @@ class UnloadingPermissionControllerSpec extends FreeSpec with MustMatchers with 
         consignor = Some(models.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", "AA", None)),
         consignee = Some(models.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", "AA", None)),
         containers = Seq("container 1"),
-        packages = Seq(models.RegularPackage("BB", 1, "marks and numbers"))
-      ))
+        packages = NonEmptyList.one(models.RegularPackage("BB", 1, "marks and numbers"))
+      )
+    )
   )
   "post" - {
 
@@ -107,7 +109,7 @@ class UnloadingPermissionControllerSpec extends FreeSpec with MustMatchers with 
         traderAtDestination = viewmodels.TraderAtDestinationWithEori("Trader EORI", None, None, None, None, None),
         presentationOffice = "Presentation office",
         seals = Seq("seal 1"),
-        goodsItems = Seq(
+        goodsItems = NonEmptyList.one(
           viewmodels.GoodsItem(
             itemNumber = 1,
             commodityCode = None,
@@ -126,7 +128,7 @@ class UnloadingPermissionControllerSpec extends FreeSpec with MustMatchers with 
             consignor = Some(viewmodels.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", country, None)),
             consignee = Some(viewmodels.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", country, None)),
             containers = Seq("container 1"),
-            packages = Seq(viewmodels.RegularPackage(kindOfPackage, 1, "marks and numbers"))
+            packages = NonEmptyList.one(viewmodels.RegularPackage(kindOfPackage, 1, "marks and numbers"))
           )
         )
       )

--- a/test/generators/GeneratorHelpers.scala
+++ b/test/generators/GeneratorHelpers.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+import org.scalacheck.Gen
+import org.scalacheck.Shrink
+
+trait GeneratorHelpers {
+
+  implicit def dontShrink[A]: Shrink[A] = Shrink.shrinkAny
+
+  def stringWithMaxLength(maxLength: Int): Gen[String] =
+    for {
+      length <- Gen.choose(1, maxLength)
+      chars  <- Gen.listOfN(length, Gen.alphaNumChar)
+    } yield chars.mkString
+
+  def listWithMaxSize[T](maxSize: Int, gen: Gen[T]): Gen[Seq[T]] =
+    for {
+      size  <- Gen.choose(0, maxSize)
+      items <- Gen.listOfN(size, gen)
+    } yield items
+
+  def nonEmptyListWithMaxSize[T](maxSize: Int, gen: Gen[T]): Gen[Seq[T]] =
+    for {
+      size  <- Gen.choose(1, maxSize)
+      items <- Gen.listOfN(size, gen)
+    } yield items
+
+  def datesBetween(min: LocalDate, max: LocalDate): Gen[LocalDate] = {
+
+    def toMillis(date: LocalDate): Long =
+      date.atStartOfDay.atZone(ZoneOffset.UTC).toInstant.toEpochMilli
+
+    Gen.choose(toMillis(min), toMillis(max)).map {
+      millis =>
+        Instant.ofEpochMilli(millis).atOffset(ZoneOffset.UTC).toLocalDate
+    }
+  }
+}

--- a/test/generators/GeneratorHelpers.scala
+++ b/test/generators/GeneratorHelpers.scala
@@ -20,6 +20,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 
+import cats.data.NonEmptyList
 import org.scalacheck.Gen
 import org.scalacheck.Shrink
 
@@ -39,11 +40,12 @@ trait GeneratorHelpers {
       items <- Gen.listOfN(size, gen)
     } yield items
 
-  def nonEmptyListWithMaxSize[T](maxSize: Int, gen: Gen[T]): Gen[Seq[T]] =
+  def nonEmptyListWithMaxSize[T](maxSize: Int, gen: Gen[T]): Gen[NonEmptyList[T]] =
     for {
-      size  <- Gen.choose(1, maxSize)
-      items <- Gen.listOfN(size, gen)
-    } yield items
+      head     <- gen
+      tailSize <- Gen.choose(1, maxSize - 1)
+      tail     <- Gen.listOfN(tailSize, gen)
+    } yield NonEmptyList(head, tail)
 
   def datesBetween(min: LocalDate, max: LocalDate): Gen[LocalDate] = {
 

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -195,7 +195,7 @@ trait ModelGenerators extends GeneratorHelpers {
         consignor            <- Gen.option(arbitrary[Consignor])
         consignee            <- Gen.option(arbitrary[Consignee])
         containers           <- listWithMaxSize(9, stringWithMaxLength(17))
-        packages             <- listWithMaxSize(9, arbitrary[Package])
+        packages             <- nonEmptyListWithMaxSize(9, arbitrary[Package])
       } yield
         GoodsItem(
           itemNumber,
@@ -242,7 +242,7 @@ trait ModelGenerators extends GeneratorHelpers {
         traderAtDestination <- arbitrary[TraderAtDestination]
         presentationOffice  <- stringWithMaxLength(8)
         seals               <- listWithMaxSize(9, stringWithMaxLength(20))
-        goodsItems          <- listWithMaxSize(9, arbitrary[GoodsItem])
+        goodsItems          <- nonEmptyListWithMaxSize(9, arbitrary[GoodsItem])
       } yield
         PermissionToStartUnloading(
           mrn,

--- a/test/generators/ReferenceModelGenerators.scala
+++ b/test/generators/ReferenceModelGenerators.scala
@@ -24,7 +24,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 
-trait ReferenceModelGenerators extends ModelGenerators {
+trait ReferenceModelGenerators extends GeneratorHelpers {
 
   implicit lazy val arbitraryCountry: Arbitrary[Country] =
     Arbitrary {

--- a/test/generators/ViewmodelGenerators.scala
+++ b/test/generators/ViewmodelGenerators.scala
@@ -196,7 +196,7 @@ trait ViewmodelGenerators extends GeneratorHelpers with ReferenceModelGenerators
         consignor            <- Gen.option(arbitrary[Consignor])
         consignee            <- Gen.option(arbitrary[Consignee])
         containers           <- listWithMaxSize(9, stringWithMaxLength(17))
-        packages             <- listWithMaxSize(9, arbitrary[Package])
+        packages             <- nonEmptyListWithMaxSize(9, arbitrary[Package])
       } yield
         GoodsItem(
           itemNumber,
@@ -231,7 +231,7 @@ trait ViewmodelGenerators extends GeneratorHelpers with ReferenceModelGenerators
         principal           <- arbitrary[Principal]
         traderAtDestination <- arbitrary[TraderAtDestination]
         presentationOffice  <- stringWithMaxLength(8)
-        seals               <- nonEmptyListWithMaxSize(9, stringWithMaxLength(20))
+        seals               <- listWithMaxSize(9, stringWithMaxLength(20))
         goodsItems          <- nonEmptyListWithMaxSize(9, arbitrary[GoodsItem])
       } yield
         PermissionToStartUnloading(

--- a/test/json/NonEmptyListOpsSpec.scala
+++ b/test/json/NonEmptyListOpsSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package json
+
+import cats.data.NonEmptyList
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import play.api.libs.json.JsError
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Json
+import json.NonEmptyListOps._
+
+class NonEmptyListOpsSpec extends FreeSpec with MustMatchers {
+
+  "ops" - {
+
+    "must write a non empty list with no tail" in {
+
+      val json = "[1]"
+
+      val nonEmptyList = NonEmptyList.one(1)
+
+      Json.toJson(nonEmptyList).toString mustEqual json
+    }
+
+    "must write a non empty list with a tail" in {
+
+      val json = "[1,2,3]"
+
+      val nonEmptyList = NonEmptyList(1, List(2, 3))
+
+      Json.toJson(nonEmptyList).toString mustEqual json
+    }
+  }
+
+  "must read a list with one item" in {
+
+    val json = Json.arr(1)
+
+    json.validate[NonEmptyList[Int]] mustEqual JsSuccess(NonEmptyList.one(1))
+  }
+
+  "must read a list with multiple items" in {
+
+    val json = Json.arr(1, 2, 3)
+
+    json.validate[NonEmptyList[Int]] mustEqual JsSuccess(NonEmptyList(1, List(2, 3)))
+  }
+
+  "must fail to read an empty list" in {
+
+    val json = Json.arr()
+
+    json.validate[NonEmptyList[Int]] mustBe a[JsError]
+  }
+}

--- a/test/models/UnloadingPermissionSpec.scala
+++ b/test/models/UnloadingPermissionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.MustMatchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.JsSuccess
 import play.api.libs.json.Json
+import json.NonEmptyListOps._
 
 class UnloadingPermissionSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks with ModelGenerators {
 

--- a/test/services/ConversionServiceSpec.scala
+++ b/test/services/ConversionServiceSpec.scala
@@ -18,6 +18,7 @@ package services
 
 import java.time.LocalDate
 
+import cats.data.NonEmptyList
 import cats.implicits._
 import cats.data.Validated.Valid
 import cats.scalatest.ValidatedMatchers
@@ -69,7 +70,7 @@ class ConversionServiceSpec
     traderAtDestination = models.TraderAtDestinationWithEori("Trader EORI", None, None, None, None, None),
     presentationOffice = "Presentation office",
     seals = Seq("seal 1"),
-    goodsItems = Seq(
+    goodsItems = NonEmptyList.one(
       models.GoodsItem(
         itemNumber = 1,
         commodityCode = None,
@@ -88,12 +89,15 @@ class ConversionServiceSpec
         consignor = Some(models.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", countries.head.code, None)),
         consignee = Some(models.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", countries.head.code, None)),
         containers = Seq("container 1"),
-        packages = Seq(
+        packages = NonEmptyList(
           models.BulkPackage(kindsOfPackage.head.code, Some("numbers")),
-          models.UnpackedPackage(kindsOfPackage.head.code, 1, Some("marks")),
-          models.RegularPackage(kindsOfPackage.head.code, 1, "marks and numbers")
+          List(
+            models.UnpackedPackage(kindsOfPackage.head.code, 1, Some("marks")),
+            models.RegularPackage(kindsOfPackage.head.code, 1, "marks and numbers")
+          )
         )
-      ))
+      )
+    )
   )
 
   "convertUnloadingPermission" - {
@@ -122,7 +126,7 @@ class ConversionServiceSpec
         traderAtDestination = viewmodels.TraderAtDestinationWithEori("Trader EORI", None, None, None, None, None),
         presentationOffice = "Presentation office",
         seals = Seq("seal 1"),
-        goodsItems = Seq(
+        goodsItems = NonEmptyList.one(
           viewmodels.GoodsItem(
             itemNumber = 1,
             commodityCode = None,
@@ -141,10 +145,12 @@ class ConversionServiceSpec
             consignor = Some(viewmodels.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", countries.head, None)),
             consignee = Some(viewmodels.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", countries.head, None)),
             containers = Seq("container 1"),
-            packages = Seq(
+            packages = NonEmptyList(
               viewmodels.BulkPackage(kindsOfPackage.head, Some("numbers")),
-              viewmodels.UnpackedPackage(kindsOfPackage.head, 1, Some("marks")),
-              viewmodels.RegularPackage(kindsOfPackage.head, 1, "marks and numbers")
+              List(
+                viewmodels.UnpackedPackage(kindsOfPackage.head, 1, Some("marks")),
+                viewmodels.RegularPackage(kindsOfPackage.head, 1, "marks and numbers")
+              )
             )
           )
         )

--- a/test/services/GoodsItemConverterSpec.scala
+++ b/test/services/GoodsItemConverterSpec.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import cats.data.NonEmptyList
 import cats.scalatest.ValidatedMatchers
 import cats.scalatest.ValidatedValues
 import models.reference.AdditionalInformation
@@ -56,10 +57,12 @@ class GoodsItemConverterSpec extends FreeSpec with MustMatchers with ValidatedMa
         consignor = Some(models.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", countries.head.code, None)),
         consignee = Some(models.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", countries.head.code, None)),
         containers = Seq("container 1"),
-        packages = Seq(
+        packages = NonEmptyList(
           models.BulkPackage(kindsOfPackage.head.code, Some("numbers")),
-          models.UnpackedPackage(kindsOfPackage.head.code, 1, Some("marks")),
-          models.RegularPackage(kindsOfPackage.head.code, 1, "marks and numbers")
+          List(
+            models.UnpackedPackage(kindsOfPackage.head.code, 1, Some("marks")),
+            models.RegularPackage(kindsOfPackage.head.code, 1, "marks and numbers")
+          )
         )
       )
 
@@ -81,10 +84,12 @@ class GoodsItemConverterSpec extends FreeSpec with MustMatchers with ValidatedMa
         consignor = Some(viewmodels.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", countries.head, None)),
         consignee = Some(viewmodels.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", countries.head, None)),
         containers = Seq("container 1"),
-        packages = Seq(
+        packages = NonEmptyList(
           viewmodels.BulkPackage(kindsOfPackage.head, Some("numbers")),
-          viewmodels.UnpackedPackage(kindsOfPackage.head, 1, Some("marks")),
-          viewmodels.RegularPackage(kindsOfPackage.head, 1, "marks and numbers")
+          List(
+            viewmodels.UnpackedPackage(kindsOfPackage.head, 1, Some("marks")),
+            viewmodels.RegularPackage(kindsOfPackage.head, 1, "marks and numbers")
+          )
         )
       )
 
@@ -113,10 +118,12 @@ class GoodsItemConverterSpec extends FreeSpec with MustMatchers with ValidatedMa
         consignor = Some(models.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", invalidCode, None)),
         consignee = Some(models.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", invalidCode, None)),
         containers = Seq("container 1"),
-        packages = Seq(
+        packages = NonEmptyList(
           models.BulkPackage(invalidCode, Some("numbers")),
-          models.UnpackedPackage(invalidCode, 1, Some("marks")),
-          models.RegularPackage(invalidCode, 1, "marks and numbers")
+          List(
+            models.UnpackedPackage(invalidCode, 1, Some("marks")),
+            models.RegularPackage(invalidCode, 1, "marks and numbers")
+          )
         )
       )
 

--- a/test/services/UnloadingPermissionConverterSpec.scala
+++ b/test/services/UnloadingPermissionConverterSpec.scala
@@ -18,6 +18,7 @@ package services
 
 import java.time.LocalDate
 
+import cats.data.NonEmptyList
 import cats.scalatest.ValidatedMatchers
 import cats.scalatest.ValidatedValues
 import models.DeclarationType
@@ -55,7 +56,7 @@ class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with V
         traderAtDestination = models.TraderAtDestinationWithEori("Trader EORI", None, None, None, None, None),
         presentationOffice = "Presentation office",
         seals = Seq("seal 1"),
-        goodsItems = Seq(
+        goodsItems = NonEmptyList.one(
           models.GoodsItem(
             itemNumber = 1,
             commodityCode = None,
@@ -74,12 +75,15 @@ class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with V
             consignor = Some(models.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", countries.head.code, None)),
             consignee = Some(models.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", countries.head.code, None)),
             containers = Seq("container 1"),
-            packages = Seq(
+            packages = NonEmptyList(
               models.BulkPackage(kindsOfPackage.head.code, Some("numbers")),
-              models.UnpackedPackage(kindsOfPackage.head.code, 1, Some("marks")),
-              models.RegularPackage(kindsOfPackage.head.code, 1, "marks and numbers")
+              List(
+                models.UnpackedPackage(kindsOfPackage.head.code, 1, Some("marks")),
+                models.RegularPackage(kindsOfPackage.head.code, 1, "marks and numbers")
+              )
             )
-          ))
+          )
+        )
       )
 
       val expectedResult = viewmodels.PermissionToStartUnloading(
@@ -96,7 +100,7 @@ class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with V
         traderAtDestination = viewmodels.TraderAtDestinationWithEori("Trader EORI", None, None, None, None, None),
         presentationOffice = "Presentation office",
         seals = Seq("seal 1"),
-        goodsItems = Seq(
+        goodsItems = NonEmptyList.one(
           viewmodels.GoodsItem(
             itemNumber = 1,
             commodityCode = None,
@@ -115,10 +119,12 @@ class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with V
             consignor = Some(viewmodels.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", countries.head, None)),
             consignee = Some(viewmodels.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", countries.head, None)),
             containers = Seq("container 1"),
-            packages = Seq(
+            packages = NonEmptyList(
               viewmodels.BulkPackage(kindsOfPackage.head, Some("numbers")),
-              viewmodels.UnpackedPackage(kindsOfPackage.head, 1, Some("marks")),
-              viewmodels.RegularPackage(kindsOfPackage.head, 1, "marks and numbers")
+              List(
+                viewmodels.UnpackedPackage(kindsOfPackage.head, 1, Some("marks")),
+                viewmodels.RegularPackage(kindsOfPackage.head, 1, "marks and numbers")
+              )
             )
           )
         )
@@ -144,7 +150,7 @@ class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with V
         traderAtDestination = models.TraderAtDestinationWithEori("Trader EORI", Some("name"), Some("street"), Some("postCode"), Some("city"), Some(invalidCode)),
         presentationOffice = "Presentation office",
         seals = Seq("seal 1"),
-        goodsItems = Seq(
+        goodsItems = NonEmptyList.one(
           models.GoodsItem(
             itemNumber = 1,
             commodityCode = None,
@@ -163,12 +169,15 @@ class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with V
             consignor = Some(models.Consignor("consignor name", "consignor street", "consignor postCode", "consignor city", invalidCode, None)),
             consignee = Some(models.Consignee("consignee name", "consignee street", "consignee postCode", "consignee city", invalidCode, None)),
             containers = Seq("container 1"),
-            packages = Seq(
+            packages = NonEmptyList(
               models.BulkPackage(invalidCode, Some("numbers")),
-              models.UnpackedPackage(invalidCode, 1, Some("marks")),
-              models.RegularPackage(invalidCode, 1, "marks and numbers")
+              List(
+                models.UnpackedPackage(invalidCode, 1, Some("marks")),
+                models.RegularPackage(invalidCode, 1, "marks and numbers")
+              )
             )
-          ))
+          )
+        )
       )
 
       val result = UnloadingPermissionConverter.toViewModel(permission, countries, additionalInfo, kindsOfPackage, documentTypes)

--- a/test/viewmodels/PermissionToStartUnloadingSpec.scala
+++ b/test/viewmodels/PermissionToStartUnloadingSpec.scala
@@ -16,6 +16,7 @@
 
 package viewmodels
 
+import cats.data.NonEmptyList
 import generators.ViewmodelGenerators
 import models.reference.Country
 import org.scalacheck.Arbitrary.arbitrary
@@ -73,7 +74,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
             val goodsItemWithConsignor1 = goodsItem copy (consignor = Some(consignor1))
             val goodsItemWithConsignor2 = goodsItem copy (consignor = Some(consignor2))
 
-            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithConsignor1, goodsItemWithConsignor2))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList(goodsItemWithConsignor1, List(goodsItemWithConsignor2)))
 
             updatedPermission.consignor mustBe empty
           }
@@ -94,7 +95,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
           val itemsWithNoConsignor = items1.map(_ copy (consignor = None))
           val itemsWithConsignor   = items2.map(_ copy (consignor = Some(consignor)))
 
-          val updatedPermission = permission copy (goodsItems = itemsWithNoConsignor ++ itemsWithConsignor)
+          val updatedPermission = permission copy (goodsItems = itemsWithNoConsignor.concatNel(itemsWithConsignor))
 
           updatedPermission.consignor mustBe empty
       }
@@ -139,7 +140,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
             val goodsItemWithConsignee1 = goodsItem copy (consignee = Some(consignee1))
             val goodsItemWithConsignee2 = goodsItem copy (consignee = Some(consignee2))
 
-            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithConsignee1, goodsItemWithConsignee2))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList(goodsItemWithConsignee1, List(goodsItemWithConsignee2)))
 
             updatedPermission.consignee mustBe empty
           }
@@ -160,7 +161,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
           val itemsWithNoConsignee = items1.map(_ copy (consignee = None))
           val itemsWithConsignee   = items2.map(_ copy (consignee = Some(consignee)))
 
-          val updatedPermission = permission copy (goodsItems = itemsWithNoConsignee ++ itemsWithConsignee)
+          val updatedPermission = permission copy (goodsItems = itemsWithNoConsignee.concatNel(itemsWithConsignee))
 
           updatedPermission.consignee mustBe empty
       }
@@ -193,7 +194,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
             val goodsItemWithCountryOfDispatch1 = goodsItem copy (countryOfDispatch = countryOfDispatch1)
             val goodsItemWithCountryOfDispatch2 = goodsItem copy (countryOfDispatch = countryOfDispatch2)
 
-            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithCountryOfDispatch1, goodsItemWithCountryOfDispatch2))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList(goodsItemWithCountryOfDispatch1, List(goodsItemWithCountryOfDispatch2)))
 
             updatedPermission.countryOfDispatch mustBe empty
           }
@@ -227,7 +228,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
             val goodsItemWithCountryOfDestination1 = goodsItem copy (countryOfDestination = countryOfDestination1)
             val goodsItemWithCountryOfDestination2 = goodsItem copy (countryOfDestination = countryOfDestination2)
 
-            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithCountryOfDestination1, goodsItemWithCountryOfDestination2))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList(goodsItemWithCountryOfDestination1, List(goodsItemWithCountryOfDestination2)))
 
             updatedPermission.countryOfDestination mustBe empty
           }
@@ -255,7 +256,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
           (permission, container1, container2) =>
             val updatedGoodsItem = permission.goodsItems.head copy (containers = Seq(container1, container2))
 
-            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
             updatedPermission.printListOfItems mustEqual true
         }
@@ -265,9 +266,9 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
 
         forAll(arbitrary[PermissionToStartUnloading], arbitrary[Package], arbitrary[Package]) {
           (permission, package1, package2) =>
-            val updatedGoodsItem = permission.goodsItems.head copy (packages = Seq(package1, package2))
+            val updatedGoodsItem = permission.goodsItems.head copy (packages = NonEmptyList(package1, List(package2)))
 
-            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
             updatedPermission.printListOfItems mustEqual true
         }
@@ -285,7 +286,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
           case (permission, mentions) =>
             val updatedGoodsItem = permission.goodsItems.head copy (specialMentions = mentions)
 
-            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
             updatedPermission.printListOfItems mustEqual true
         }
@@ -303,7 +304,7 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
           case (permission, documents) =>
             val updatedGoodsItem = permission.goodsItems.head copy (producedDocuments = documents)
 
-            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+            val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
             updatedPermission.printListOfItems mustEqual true
         }
@@ -317,12 +318,12 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
             case (permission, containers, onePackage, mentions, documents) =>
               val updatedGoodsItem = permission.goodsItems.head.copy(
                 containers = containers,
-                packages = Seq(onePackage),
+                packages = NonEmptyList.one(onePackage),
                 specialMentions = mentions,
                 producedDocuments = documents
               )
 
-              val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+              val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
               updatedPermission.printListOfItems mustEqual false
           }
@@ -364,12 +365,12 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
         case (permission, containers, onePackage, mentions, documents) =>
           val updatedGoodsItem = permission.goodsItems.head.copy(
             containers = containers,
-            packages = Seq(onePackage),
+            packages = NonEmptyList.one(onePackage),
             specialMentions = mentions,
             producedDocuments = documents
           )
 
-          val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+          val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
           updatedPermission.printVariousConsignors mustEqual false
       }
@@ -440,12 +441,12 @@ class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with Sca
         case (permission, containers, onePackage, mentions, documents) =>
           val updatedGoodsItem = permission.goodsItems.head.copy(
             containers = containers,
-            packages = Seq(onePackage),
+            packages = NonEmptyList.one(onePackage),
             specialMentions = mentions,
             producedDocuments = documents
           )
 
-          val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+          val updatedPermission = permission copy (goodsItems = NonEmptyList.one(updatedGoodsItem))
 
           updatedPermission.printVariousConsignees mustEqual false
       }

--- a/test/viewmodels/PermissionToStartUnloadingSpec.scala
+++ b/test/viewmodels/PermissionToStartUnloadingSpec.scala
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import generators.ViewmodelGenerators
+import models.reference.Country
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatest.OptionValues
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class PermissionToStartUnloadingSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks with ViewmodelGenerators with OptionValues {
+
+  private val genPermissionWithoutListOfItems = for {
+    permission <- arbitrary[PermissionToStartUnloading]
+    containers <- listWithMaxSize(1, stringWithMaxLength(17))
+    onePackage <- arbitrary[Package]
+    mentions   <- listWithMaxSize(4, arbitrary[SpecialMention])
+    documents  <- listWithMaxSize(4, arbitrary[ProducedDocument])
+  } yield (permission, containers, onePackage, mentions, documents)
+
+  "must have a consignor" - {
+
+    "when all goods items have the same consignor" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[Consignor]) {
+        (permission, consignor) =>
+          val goodsItemsWithConsignor = permission.goodsItems.map(_ copy (consignor = Some(consignor)))
+
+          val permissionWithConsignors = permission copy (goodsItems = goodsItemsWithConsignor)
+
+          permissionWithConsignors.consignor.value mustEqual consignor
+      }
+    }
+  }
+
+  "must not have a consignor" - {
+
+    "when no goods items have consignors" in {
+
+      forAll(arbitrary[PermissionToStartUnloading]) {
+        permission =>
+          val goodsItemsWithNoConsignors = permission.goodsItems.map(_ copy (consignor = None))
+
+          val permissionWithNoConsignors = permission copy (goodsItems = goodsItemsWithNoConsignors)
+
+          permissionWithNoConsignors.consignor mustBe empty
+      }
+    }
+
+    "when some goods items have different consignors" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Consignor], arbitrary[Consignor]) {
+        (permission, goodsItem, consignor1, consignor2) =>
+          whenever(consignor1 != consignor2) {
+
+            val goodsItemWithConsignor1 = goodsItem copy (consignor = Some(consignor1))
+            val goodsItemWithConsignor2 = goodsItem copy (consignor = Some(consignor2))
+
+            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithConsignor1, goodsItemWithConsignor2))
+
+            updatedPermission.consignor mustBe empty
+          }
+      }
+    }
+
+    "when some goods items have no consignor and the rest all have the same consignor" in {
+
+      val gen = for {
+        permission <- arbitrary[PermissionToStartUnloading]
+        items1     <- nonEmptyListWithMaxSize(5, arbitrary[GoodsItem])
+        items2     <- nonEmptyListWithMaxSize(5, arbitrary[GoodsItem])
+        consignor  <- arbitrary[Consignor]
+      } yield (permission, items1, items2, consignor)
+
+      forAll(gen) {
+        case (permission, items1, items2, consignor) =>
+          val itemsWithNoConsignor = items1.map(_ copy (consignor = None))
+          val itemsWithConsignor   = items2.map(_ copy (consignor = Some(consignor)))
+
+          val updatedPermission = permission copy (goodsItems = itemsWithNoConsignor ++ itemsWithConsignor)
+
+          updatedPermission.consignor mustBe empty
+      }
+    }
+  }
+
+  "must have a consignee" - {
+
+    "when all goods items have the same consignee" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[Consignee]) {
+        (permission, consignee) =>
+          val goodsItemsWithConsignee = permission.goodsItems.map(_ copy (consignee = Some(consignee)))
+
+          val permissionWithConsignees = permission copy (goodsItems = goodsItemsWithConsignee)
+
+          permissionWithConsignees.consignee.value mustEqual consignee
+      }
+    }
+  }
+
+  "must not have a consignee" - {
+
+    "when no goods items have consignees" in {
+
+      forAll(arbitrary[PermissionToStartUnloading]) {
+        permission =>
+          val goodsItemsWithNoConsignees = permission.goodsItems.map(_ copy (consignee = None))
+
+          val permissionWithNoConsignees = permission copy (goodsItems = goodsItemsWithNoConsignees)
+
+          permissionWithNoConsignees.consignee mustBe empty
+      }
+    }
+
+    "when some goods items have different consignees" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Consignee], arbitrary[Consignee]) {
+        (permission, goodsItem, consignee1, consignee2) =>
+          whenever(consignee1 != consignee2) {
+
+            val goodsItemWithConsignee1 = goodsItem copy (consignee = Some(consignee1))
+            val goodsItemWithConsignee2 = goodsItem copy (consignee = Some(consignee2))
+
+            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithConsignee1, goodsItemWithConsignee2))
+
+            updatedPermission.consignee mustBe empty
+          }
+      }
+    }
+
+    "when some goods items have no consignee and the rest all have the same consignee" in {
+
+      val gen = for {
+        permission <- arbitrary[PermissionToStartUnloading]
+        items1     <- nonEmptyListWithMaxSize(5, arbitrary[GoodsItem])
+        items2     <- nonEmptyListWithMaxSize(5, arbitrary[GoodsItem])
+        consignee  <- arbitrary[Consignee]
+      } yield (permission, items1, items2, consignee)
+
+      forAll(gen) {
+        case (permission, items1, items2, consignee) =>
+          val itemsWithNoConsignee = items1.map(_ copy (consignee = None))
+          val itemsWithConsignee   = items2.map(_ copy (consignee = Some(consignee)))
+
+          val updatedPermission = permission copy (goodsItems = itemsWithNoConsignee ++ itemsWithConsignee)
+
+          updatedPermission.consignee mustBe empty
+      }
+    }
+  }
+
+  "must have a country of dispatch" - {
+
+    "when all goods items have the same country of dispatch" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[Country]) {
+        (permission, countryOfDispatch) =>
+          val goodsItemsWithCountryOfDispatch = permission.goodsItems.map(_ copy (countryOfDispatch = countryOfDispatch))
+
+          val permissionWithCountriesOfDispatch = permission copy (goodsItems = goodsItemsWithCountryOfDispatch)
+
+          permissionWithCountriesOfDispatch.countryOfDispatch.value mustEqual countryOfDispatch
+      }
+    }
+  }
+
+  "must not have a country of dispatch" - {
+
+    "when some goods items have different countries of dispatch" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Country], arbitrary[Country]) {
+        (permission, goodsItem, countryOfDispatch1, countryOfDispatch2) =>
+          whenever(countryOfDispatch1 != countryOfDispatch2) {
+
+            val goodsItemWithCountryOfDispatch1 = goodsItem copy (countryOfDispatch = countryOfDispatch1)
+            val goodsItemWithCountryOfDispatch2 = goodsItem copy (countryOfDispatch = countryOfDispatch2)
+
+            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithCountryOfDispatch1, goodsItemWithCountryOfDispatch2))
+
+            updatedPermission.countryOfDispatch mustBe empty
+          }
+      }
+    }
+  }
+
+  "must have a country of destination" - {
+
+    "when all goods items have the same country of destination" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[Country]) {
+        (permission, countryOfDestination) =>
+          val goodsItemsWithCountryOfDestination = permission.goodsItems.map(_ copy (countryOfDestination = countryOfDestination))
+
+          val permissionWithCountriesOfDestination = permission copy (goodsItems = goodsItemsWithCountryOfDestination)
+
+          permissionWithCountriesOfDestination.countryOfDestination.value mustEqual countryOfDestination
+      }
+    }
+  }
+
+  "must not have a country of destination" - {
+
+    "when some goods items have different countries of destination" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Country], arbitrary[Country]) {
+        (permission, goodsItem, countryOfDestination1, countryOfDestination2) =>
+          whenever(countryOfDestination1 != countryOfDestination2) {
+
+            val goodsItemWithCountryOfDestination1 = goodsItem copy (countryOfDestination = countryOfDestination1)
+            val goodsItemWithCountryOfDestination2 = goodsItem copy (countryOfDestination = countryOfDestination2)
+
+            val updatedPermission = permission copy (goodsItems = Seq(goodsItemWithCountryOfDestination1, goodsItemWithCountryOfDestination2))
+
+            updatedPermission.countryOfDestination mustBe empty
+          }
+      }
+    }
+  }
+
+  "must indicate that a list of items should be printed" - {
+
+    "when there are more than 1 goods items" in {
+
+      forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem]) {
+        (permission, extraGoodsItem) =>
+          val updatedPermission = permission copy (goodsItems = permission.goodsItems :+ extraGoodsItem)
+
+          updatedPermission.printListOfItems mustEqual true
+      }
+    }
+
+    "when there is a single goods item" - {
+
+      "with more than 1 container" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], stringWithMaxLength(17), stringWithMaxLength(17)) {
+          (permission, container1, container2) =>
+            val updatedGoodsItem = permission.goodsItems.head copy (containers = Seq(container1, container2))
+
+            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+            updatedPermission.printListOfItems mustEqual true
+        }
+      }
+
+      "with more than one package" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[Package], arbitrary[Package]) {
+          (permission, package1, package2) =>
+            val updatedGoodsItem = permission.goodsItems.head copy (packages = Seq(package1, package2))
+
+            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+            updatedPermission.printListOfItems mustEqual true
+        }
+      }
+
+      "with more than 4 special mentions" in {
+
+        val gen = for {
+          permission       <- arbitrary[PermissionToStartUnloading]
+          numberOfMentions <- Gen.choose(5, 99)
+          mentions         <- Gen.listOfN(numberOfMentions, arbitrary[SpecialMention])
+        } yield (permission, mentions)
+
+        forAll(gen) {
+          case (permission, mentions) =>
+            val updatedGoodsItem = permission.goodsItems.head copy (specialMentions = mentions)
+
+            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+            updatedPermission.printListOfItems mustEqual true
+        }
+      }
+
+      "with more than 4 produced documents" in {
+
+        val gen = for {
+          permission        <- arbitrary[PermissionToStartUnloading]
+          numberOfDocuments <- Gen.choose(5, 99)
+          documents         <- Gen.listOfN(numberOfDocuments, arbitrary[ProducedDocument])
+        } yield (permission, documents)
+
+        forAll(gen) {
+          case (permission, documents) =>
+            val updatedGoodsItem = permission.goodsItems.head copy (producedDocuments = documents)
+
+            val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+            updatedPermission.printListOfItems mustEqual true
+        }
+      }
+
+      "must indicate that a list of items should not be printed" - {
+
+        "when there is one goods item with at most one container, one package, at most four special mentions and at most four produced documents" in {
+
+          forAll(genPermissionWithoutListOfItems) {
+            case (permission, containers, onePackage, mentions, documents) =>
+              val updatedGoodsItem = permission.goodsItems.head.copy(
+                containers = containers,
+                packages = Seq(onePackage),
+                specialMentions = mentions,
+                producedDocuments = documents
+              )
+
+              val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+              updatedPermission.printListOfItems mustEqual false
+          }
+        }
+      }
+    }
+  }
+
+  "must indicate that various consignors be printed" - {
+
+    "when a list of items should be printed" - {
+
+      "and there are goods items with different consignors" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Consignor], arbitrary[Consignor]) {
+          (permission, goodsItem, consignor1, consignor2) =>
+            whenever(consignor1 != consignor2) {
+
+              val goodsItemsWithConsignor = permission.goodsItems.map(_ copy (consignor = Some(consignor1)))
+
+              val updatedGoodsItem = goodsItem copy (consignor = Some(consignor2))
+
+              val allGoodsItems = goodsItemsWithConsignor :+ updatedGoodsItem
+
+              val updatedPermission = permission copy (goodsItems = allGoodsItems)
+
+              updatedPermission.printVariousConsignors mustEqual true
+            }
+        }
+      }
+    }
+  }
+
+  "must indicate that various consignors should not be printed" - {
+
+    "when a list of items should not be printed" in {
+
+      forAll(genPermissionWithoutListOfItems) {
+        case (permission, containers, onePackage, mentions, documents) =>
+          val updatedGoodsItem = permission.goodsItems.head.copy(
+            containers = containers,
+            packages = Seq(onePackage),
+            specialMentions = mentions,
+            producedDocuments = documents
+          )
+
+          val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+          updatedPermission.printVariousConsignors mustEqual false
+      }
+    }
+
+    "when a list of items should be printed" - {
+
+      "and no goods items have consignors" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem]) {
+          (permission, goodsItems) =>
+            val allGoodsItems = permission.goodsItems :+ goodsItems
+
+            val updatedGoodsItems = allGoodsItems.map(_ copy (consignor = None))
+
+            val updatedPermission = permission copy (goodsItems = updatedGoodsItems)
+
+            updatedPermission.printVariousConsignors mustEqual false
+        }
+      }
+
+      "and there is a single consignor" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Consignor]) {
+          (permission, goodsItems, consignor) =>
+            val allGoodsItems = permission.goodsItems :+ goodsItems
+
+            val updatedGoodsItems = allGoodsItems.map(_ copy (consignor = Some(consignor)))
+
+            val updatedPermission = permission copy (goodsItems = updatedGoodsItems)
+
+            updatedPermission.printVariousConsignors mustEqual false
+        }
+      }
+    }
+  }
+
+  "must indicate that various consignees be printed" - {
+
+    "when a list of items should be printed" - {
+
+      "and there are goods items with different consignees" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Consignee], arbitrary[Consignee]) {
+          (permission, goodsItem, consignee1, consignee2) =>
+            whenever(consignee1 != consignee2) {
+
+              val goodsItemsWithConsignee = permission.goodsItems.map(_ copy (consignee = Some(consignee1)))
+
+              val updatedGoodsItem = goodsItem copy (consignee = Some(consignee2))
+
+              val allGoodsItems = goodsItemsWithConsignee :+ updatedGoodsItem
+
+              val updatedPermission = permission copy (goodsItems = allGoodsItems)
+
+              updatedPermission.printVariousConsignees mustEqual true
+            }
+        }
+      }
+    }
+  }
+
+  "must indicate that various consignees should not be printed" - {
+
+    "when a list of items should not be printed" in {
+
+      forAll(genPermissionWithoutListOfItems) {
+        case (permission, containers, onePackage, mentions, documents) =>
+          val updatedGoodsItem = permission.goodsItems.head.copy(
+            containers = containers,
+            packages = Seq(onePackage),
+            specialMentions = mentions,
+            producedDocuments = documents
+          )
+
+          val updatedPermission = permission copy (goodsItems = Seq(updatedGoodsItem))
+
+          updatedPermission.printVariousConsignees mustEqual false
+      }
+    }
+
+    "when a list of items should be printed" - {
+
+      "and no goods items have consignees" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem]) {
+          (permission, goodsItems) =>
+            val allGoodsItems = permission.goodsItems :+ goodsItems
+
+            val updatedGoodsItems = allGoodsItems.map(_ copy (consignee = None))
+
+            val updatedPermission = permission copy (goodsItems = updatedGoodsItems)
+
+            updatedPermission.printVariousConsignees mustEqual false
+        }
+      }
+
+      "and there is a single consignee" in {
+
+        forAll(arbitrary[PermissionToStartUnloading], arbitrary[GoodsItem], arbitrary[Consignee]) {
+          (permission, goodsItems, consignee) =>
+            val allGoodsItems = permission.goodsItems :+ goodsItems
+
+            val updatedGoodsItems = allGoodsItems.map(_ copy (consignee = Some(consignee)))
+
+            val updatedPermission = permission copy (goodsItems = updatedGoodsItems)
+
+            updatedPermission.printVariousConsignees mustEqual false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add some methods to the Permission to Start Unloading viewmodel which are needed for the PDF.

Use NonEmptyLists for goods items and packages to better reflect the shape of an Unloading Permission message.