### PR TITLE
CTCTRADERS-1152: Continue building out TAD functionality

### DIFF
--- a/app/config/ReferenceDataConfig.scala
+++ b/app/config/ReferenceDataConfig.scala
@@ -30,4 +30,11 @@ class ReferenceDataConfig @Inject()(config: Configuration) {
   val kindsOfPackageUrl: String        = s"$baseUrl/kinds-of-package"
   val documentTypesUrl: String         = s"$baseUrl/document-types"
   val additionalInformationUrl: String = s"$baseUrl/additional-information"
+
+  val transportModeUrl: String         = s"$baseUrl/transport-mode"
+  val controlResultUrl: String         = s"$baseUrl/control-result"
+  val previousDocumentTypesUrl: String = s"$baseUrl/previous-document-types"
+  val sensitiveGoodsCodeUrl: String    = s"$baseUrl/sensitive-goods-code"
+  val specialMentionsUrl: String       = s"$baseUrl/special-mentions"
+
 }

--- a/app/models/Package.scala
+++ b/app/models/Package.scala
@@ -16,9 +16,9 @@
 
 package models
 
+import cats.syntax.all._
 import com.lucidchart.open.xtract.XmlReader
 import play.api.libs.json._
-import cats.syntax.all._
 
 sealed trait Package
 
@@ -50,6 +50,7 @@ object Package {
     case u: UnpackedPackage => Json.toJsObject(u)(UnpackedPackage.writes)
     case r: RegularPackage  => Json.toJsObject(r)(RegularPackage.writes)
   }
+
 }
 
 final case class BulkPackage(

--- a/app/models/TransitAccompanyingDocument.scala
+++ b/app/models/TransitAccompanyingDocument.scala
@@ -21,8 +21,14 @@ import com.lucidchart.open.xtract.XmlReader
 import com.lucidchart.open.xtract.__
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
+import cats.syntax.all._
 
-final case class TransitAccompanyingDocument(localReferenceNumber: String)
+final case class TransitAccompanyingDocument(
+  localReferenceNumber: String,
+  declarationType: DeclarationType,
+  countryOfDispatch: Option[String],
+  countryOfDestination: Option[String]
+)
 
 object TransitAccompanyingDocument {
 
@@ -30,6 +36,9 @@ object TransitAccompanyingDocument {
     Json.format[TransitAccompanyingDocument]
 
   implicit val xmlReader: XmlReader[TransitAccompanyingDocument] = {
-    (__ \ "HEAHEA" \ "RefNumHEA4").read[String].map(apply)
+    ((__ \ "HEAHEA" \ "RefNumHEA4").read[String],
+     (__ \ "HEAHEA" \ "TypOfDecHEA24").read[DeclarationType],
+     (__ \ "HEAHEA" \ "CouOfDisCodHEA55").read[String].optional,
+     (__ \ "HEAHEA" \ "CouOfDesCodHEA30").read[String].optional).mapN(apply)
   }
 }

--- a/app/models/reference/ControlResult.scala
+++ b/app/models/reference/ControlResult.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+final case class ControlResult(code: String, description: String) extends CodedReferenceData
+
+object ControlResult {
+
+  implicit lazy val format: OFormat[ControlResult] =
+    Json.format[ControlResult]
+}

--- a/app/models/reference/PreviousDocumentTypes.scala
+++ b/app/models/reference/PreviousDocumentTypes.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+final case class PreviousDocumentTypes(code: String, description: String) extends CodedReferenceData
+
+object PreviousDocumentTypes {
+
+  implicit lazy val format: OFormat[PreviousDocumentTypes] =
+    Json.format[PreviousDocumentTypes]
+}

--- a/app/models/reference/SensitiveGoodsCode.scala
+++ b/app/models/reference/SensitiveGoodsCode.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+final case class SensitiveGoodsCode(code: String, description: String) extends CodedReferenceData
+
+object SensitiveGoodsCode {
+
+  implicit val writes: Writes[SensitiveGoodsCode] = (
+    (JsPath \ "code").write[String] and
+      (JsPath \ "description").write[String]
+  )(unlift(SensitiveGoodsCode.unapply))
+
+  implicit val reads: Reads[SensitiveGoodsCode] = (
+    (JsPath \ "code").read[String](readString) and
+      (JsPath \ "description").read[String]
+  )(SensitiveGoodsCode.apply _)
+}

--- a/app/models/reference/SpecialMentions.scala
+++ b/app/models/reference/SpecialMentions.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+final case class SpecialMentions(code: String, description: String) extends CodedReferenceData
+
+object SpecialMentions {
+
+  implicit lazy val format: OFormat[SpecialMentions] =
+    Json.format[SpecialMentions]
+}

--- a/app/models/reference/TransportMode.scala
+++ b/app/models/reference/TransportMode.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+final case class TransportMode(code: String, description: String) extends CodedReferenceData
+
+object TransportMode {
+
+  implicit val writes: Writes[TransportMode] = (
+    (JsPath \ "code").write[String] and
+      (JsPath \ "description").write[String]
+  )(unlift(TransportMode.unapply))
+
+  implicit val reads: Reads[TransportMode] = (
+    (JsPath \ "code").read[String](readString) and
+      (JsPath \ "description").read[String]
+  )(TransportMode.apply _)
+}

--- a/app/models/reference/package.scala
+++ b/app/models/reference/package.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+import play.api.libs.json.JsonValidationError
+import play.api.libs.json.Reads
+
+import scala.util.Success
+import scala.util.Try
+
+package object reference {
+
+  private val readStringFromInt: Reads[String] = implicitly[Reads[Int]]
+    .map(x => Try(x.toString))
+    .collect(JsonValidationError(Seq("Parsing error"))) {
+      case Success(a) => a
+    }
+
+  val readString: Reads[String] = implicitly[Reads[String]].orElse(readStringFromInt)
+}

--- a/app/services/ReferenceDataService.scala
+++ b/app/services/ReferenceDataService.scala
@@ -19,10 +19,7 @@ package services
 import cats.implicits._
 import config.ReferenceDataConfig
 import javax.inject.Inject
-import models.reference.AdditionalInformation
-import models.reference.Country
-import models.reference.DocumentType
-import models.reference.KindOfPackage
+import models.reference._
 import play.api.http.Status
 import play.api.libs.json.Reads
 import uk.gov.hmrc.http.HeaderCarrier
@@ -76,5 +73,40 @@ class ReferenceDataService @Inject()(
 
     val reads = referenceDataReads[AdditionalInformation]("additionalInformation")
     httpClient.GET[ValidationResult[Seq[AdditionalInformation]]](config.additionalInformationUrl)(reads, implicitly, implicitly)
+  }
+
+  def transportMode()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[ValidationResult[Seq[TransportMode]]] = {
+
+    val reads = referenceDataReads[TransportMode]("transportMode")
+
+    httpClient.GET[ValidationResult[Seq[TransportMode]]](config.transportModeUrl)(reads, implicitly, implicitly)
+  }
+
+  def controlResult()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[ValidationResult[Seq[ControlResult]]] = {
+
+    val reads = referenceDataReads[ControlResult]("controlResult")
+
+    httpClient.GET[ValidationResult[Seq[ControlResult]]](config.controlResultUrl)(reads, implicitly, implicitly)
+  }
+
+  def previousDocumentTypes()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[ValidationResult[Seq[PreviousDocumentTypes]]] = {
+
+    val reads = referenceDataReads[PreviousDocumentTypes]("previousDocumentTypes")
+
+    httpClient.GET[ValidationResult[Seq[PreviousDocumentTypes]]](config.previousDocumentTypesUrl)(reads, implicitly, implicitly)
+  }
+
+  def sensitiveGoodsCode()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[ValidationResult[Seq[SensitiveGoodsCode]]] = {
+
+    val reads = referenceDataReads[SensitiveGoodsCode]("sensitiveGoodsCode")
+
+    httpClient.GET[ValidationResult[Seq[SensitiveGoodsCode]]](config.sensitiveGoodsCodeUrl)(reads, implicitly, implicitly)
+  }
+
+  def specialMentions()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[ValidationResult[Seq[SpecialMentions]]] = {
+
+    val reads = referenceDataReads[SpecialMentions]("specialMentions")
+
+    httpClient.GET[ValidationResult[Seq[SpecialMentions]]](config.specialMentionsUrl)(reads, implicitly, implicitly)
   }
 }

--- a/app/services/conversion/TransitAccompanyingDocumentConversionService.scala
+++ b/app/services/conversion/TransitAccompanyingDocumentConversionService.scala
@@ -34,20 +34,12 @@ class TransitAccompanyingDocumentConversionService @Inject()(referenceData: Refe
 //    val countriesFuture      = referenceData.countries()
 //    val additionalInfoFuture = referenceData.additionalInformation()
 //    val kindsOfPackageFuture = referenceData.kindsOfPackage()
-//    val documentTypesFuture  = referenceData.documentTypes() // CL013. Document Type (Common)
-
-//    val transportMode  = referenceData.transportMode() //CL018. Transport mode
-//    val controlResultCode = referenceData.controlResultCode() //CL047 Control result // CONRESERS.ConResCodERS16
+//    val documentTypesFuture  = referenceData.documentTypes()
 //
-//    val previousDocumentTypesFuture  = referenceData.previousDocumentTypes()/// CL014. Previous document type (Common)
-//    val sensitiveGoodsCodeFuture = referenceData.sensitiveGoodsCode() //CL064
-//
-//    val specialMentionsCodeFuture = referenceData.specialMentions() //CL039
-
-  // TODO: Don't think we need guarantee type (uses the code that is pass in message)
-  // val guaranteeType = referenceData.guaranteeType() //CL051 // GUAGUA.GuaTypGUA1
-
-  //TODO: Could use the countries ref data for this
-  // val guaranteeManagementCountries = referenceData.guaranteeManagementCountries() //CL071. Country Codes (Guarantee Management - non EC) // GUAGUA.NotValForOthConPLIM2
+//    val transportMode  = referenceData.transportMode()
+//    val controlResultCode = referenceData.controlResult()
+//    val previousDocumentTypesFuture  = referenceData.previousDocumentTypes()
+//    val sensitiveGoodsCodeFuture = referenceData.sensitiveGoodsCode()
+//    val specialMentionsCodeFuture = referenceData.specialMentions()
 
 }

--- a/app/services/conversion/TransitAccompanyingDocumentConversionService.scala
+++ b/app/services/conversion/TransitAccompanyingDocumentConversionService.scala
@@ -16,7 +16,7 @@
 
 package services.conversion
 
-import cats.implicits._
+import cats.data.Validated.Invalid
 import javax.inject.Inject
 import services.ReferenceDataService
 import services.ValidationResult
@@ -29,9 +29,9 @@ class TransitAccompanyingDocumentConversionService @Inject()(referenceData: Refe
 
   def toViewModel(transitAccompanyingDocument: models.TransitAccompanyingDocument)(
     implicit ec: ExecutionContext,
-    hc: HeaderCarrier): Future[ValidationResult[viewmodels.tad.TransitAccompanyingDocument]] =
-    ???
-//    val countriesFuture      = referenceData.countries()
+    hc: HeaderCarrier): Future[ValidationResult[viewmodels.tad.TransitAccompanyingDocument]] = {
+    val countriesFuture = referenceData.countries()
+    //TODO: ref data will be needed below when we're building out the view model
 //    val additionalInfoFuture = referenceData.additionalInformation()
 //    val kindsOfPackageFuture = referenceData.kindsOfPackage()
 //    val documentTypesFuture  = referenceData.documentTypes()
@@ -42,4 +42,18 @@ class TransitAccompanyingDocumentConversionService @Inject()(referenceData: Refe
 //    val sensitiveGoodsCodeFuture = referenceData.sensitiveGoodsCode()
 //    val specialMentionsCodeFuture = referenceData.specialMentions()
 
+    for {
+      countriesResult <- countriesFuture
+    } yield {
+      (
+        countriesResult,
+      ).map(
+          (countries) => TransitAccompanyingDocumentConverter.toViewModel(transitAccompanyingDocument, countries)
+        )
+        .fold(
+          errors => Invalid(errors),
+          result => result
+        )
+    }
+  }
 }

--- a/app/services/conversion/TransitAccompanyingDocumentConverter.scala
+++ b/app/services/conversion/TransitAccompanyingDocumentConverter.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.conversion
+
+import cats.implicits._
+import cats.data.Validated.Valid
+import models.reference.Country
+import services.Converter
+import services.ValidationResult
+
+object TransitAccompanyingDocumentConverter extends Converter {
+
+  def toViewModel(transitAccompanyingDocument: models.TransitAccompanyingDocument,
+                  countries: Seq[Country]): ValidationResult[viewmodels.tad.TransitAccompanyingDocument] = {
+
+    def convertCountryOfDispatch(maybeCountryOfDispatch: Option[String]): ValidationResult[Option[Country]] =
+      maybeCountryOfDispatch match {
+        case Some(countryOfDispatch) => findReferenceData(countryOfDispatch, countries, s"countryOfDispatch").map(x => Some(x))
+        case None                    => Valid(None)
+      }
+
+    def convertCountryOfDestination(maybeCountryOfDestination: Option[String]): ValidationResult[Option[Country]] =
+      maybeCountryOfDestination match {
+        case Some(countryOfDestination) => findReferenceData(countryOfDestination, countries, s"countryOfDestination").map(x => Some(x))
+        case None                       => Valid(None)
+      }
+
+    (
+      convertCountryOfDispatch(transitAccompanyingDocument.countryOfDispatch),
+      convertCountryOfDestination(transitAccompanyingDocument.countryOfDestination),
+    ).mapN(
+      (dispatch, destination) =>
+        viewmodels.tad.TransitAccompanyingDocument(
+          transitAccompanyingDocument.localReferenceNumber,
+          transitAccompanyingDocument.declarationType,
+          dispatch,
+          destination
+      )
+    )
+
+  }
+
+}

--- a/app/services/conversion/UnloadingPermissionConversionService.scala
+++ b/app/services/conversion/UnloadingPermissionConversionService.scala
@@ -20,7 +20,6 @@ import cats.data.Validated.Invalid
 import cats.implicits._
 import javax.inject.Inject
 import services.ReferenceDataService
-import services.UnloadingPermissionConverter
 import services.ValidationResult
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/app/services/conversion/UnloadingPermissionConverter.scala
+++ b/app/services/conversion/UnloadingPermissionConverter.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package services
+package services.conversion
 
+import cats.implicits._
 import cats.data.NonEmptyList
 import cats.data.Validated.Valid
-import cats.implicits._
 import models.reference.AdditionalInformation
 import models.reference.Country
 import models.reference.DocumentType
 import models.reference.KindOfPackage
+import services._
 import utils.DateFormatter
 import utils.StringTransformer._
 

--- a/app/viewmodels/tad/TransitAccompanyingDocument.scala
+++ b/app/viewmodels/tad/TransitAccompanyingDocument.scala
@@ -15,5 +15,10 @@
  */
 
 package viewmodels.tad
+import models.DeclarationType
+import models.reference.Country
 
-case class TransitAccompanyingDocument(localReferenceNumber: String)
+case class TransitAccompanyingDocument(localReferenceNumber: String,
+                                       declarationType: DeclarationType,
+                                       singleCountryOfDispatch: Option[Country],
+                                       singleCountryOfDestination: Option[Country])

--- a/test/controllers/TransitAccompanyingDocumentControllerSpec.scala
+++ b/test/controllers/TransitAccompanyingDocumentControllerSpec.scala
@@ -143,7 +143,10 @@ class TransitAccompanyingDocumentControllerSpec
   private def declarationXml =
     <CC015A>
       <HEAHEA>
-        <RefNumHEA4>99IT9876AB88901209</RefNumHEA4>
+        <RefNumHEA4>LRNVALUE</RefNumHEA4>
+        <TypOfDecHEA24>T2</TypOfDecHEA24>
+          <CouOfDisCodHEA55>GB</CouOfDisCodHEA55>
+          <CouOfDesCodHEA30>IT</CouOfDesCodHEA30>
       </HEAHEA>
     </CC015A>
 

--- a/test/generators/ReferenceModelGenerators.scala
+++ b/test/generators/ReferenceModelGenerators.scala
@@ -16,10 +16,7 @@
 
 package generators
 
-import models.reference.AdditionalInformation
-import models.reference.Country
-import models.reference.DocumentType
-import models.reference.KindOfPackage
+import models.reference._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
@@ -58,5 +55,45 @@ trait ReferenceModelGenerators extends GeneratorHelpers {
         code        <- stringWithMaxLength(5)
         description <- stringWithMaxLength(50)
       } yield AdditionalInformation(code, description)
+    }
+
+  implicit lazy val arbitraryTransportMode: Arbitrary[TransportMode] =
+    Arbitrary {
+      for {
+        code        <- Gen.choose(0, 99)
+        description <- stringWithMaxLength(50)
+      } yield TransportMode(code.toString, description)
+    }
+
+  implicit lazy val arbitraryControlResult: Arbitrary[ControlResult] =
+    Arbitrary {
+      for {
+        code        <- stringWithMaxLength(2)
+        description <- stringWithMaxLength(50)
+      } yield ControlResult(code, description)
+    }
+
+  implicit lazy val arbitraryPreviousDocumentTypes: Arbitrary[PreviousDocumentTypes] =
+    Arbitrary {
+      for {
+        code        <- stringWithMaxLength(6)
+        description <- stringWithMaxLength(50)
+      } yield PreviousDocumentTypes(code, description)
+    }
+
+  implicit lazy val arbitrarySpecialMentions: Arbitrary[SpecialMentions] =
+    Arbitrary {
+      for {
+        code        <- stringWithMaxLength(5)
+        description <- stringWithMaxLength(50)
+      } yield SpecialMentions(code, description)
+    }
+
+  implicit lazy val arbitrarySensitiveGoodsCode: Arbitrary[SensitiveGoodsCode] =
+    Arbitrary {
+      for {
+        code        <- Gen.choose(0, 99)
+        description <- stringWithMaxLength(50)
+      } yield SensitiveGoodsCode(code.toString, description)
     }
 }

--- a/test/generators/TadViewModelGenerators.scala
+++ b/test/generators/TadViewModelGenerators.scala
@@ -15,18 +15,29 @@
  */
 
 package generators
+import models.DeclarationType
+import models.reference.Country
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import viewmodels.tad.TransitAccompanyingDocument
 
-trait TadViewModelGenerators extends GeneratorHelpers with ReferenceModelGenerators {
+trait TadViewModelGenerators extends ModelGenerators {
 
-  implicit lazy val arbitraryPermissionToStartUnloading: Arbitrary[TransitAccompanyingDocument] =
+  implicit lazy val arbitraryTransitAccompanyingDocument: Arbitrary[TransitAccompanyingDocument] =
     Arbitrary {
       for {
         localReferenceNumber <- stringWithMaxLength(22)
+        declarationType      <- arbitrary[DeclarationType]
+        countryOfDispatch    <- Gen.option(arbitrary[Country])
+        countryOfDestination <- Gen.option(arbitrary[Country])
+
       } yield
         TransitAccompanyingDocument(
-          localReferenceNumber
+          localReferenceNumber,
+          declarationType: DeclarationType,
+          countryOfDispatch,
+          countryOfDestination
         )
     }
 }

--- a/test/models/reference/SensitiveGoodsCodeSpec.scala
+++ b/test/models/reference/SensitiveGoodsCodeSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+
+import generators.ReferenceModelGenerators
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Json
+
+class SensitiveGoodsCodeSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks with ReferenceModelGenerators {
+
+  "SensitiveGoodsCode" - {
+
+    "deserialise from json to SensitiveGoodsCode" in {
+
+      forAll(arbitrary[SensitiveGoodsCode]) {
+        sensitiveGoodsCode =>
+          val json = Json.obj("code" -> sensitiveGoodsCode.code, "description" -> sensitiveGoodsCode.description)
+
+          json.validate[SensitiveGoodsCode] mustEqual JsSuccess(sensitiveGoodsCode)
+      }
+    }
+
+    "deserialise from json to SensitiveGoodsCode when code is Int" in {
+      val json = Json.obj("code" -> 12, "description" -> "description")
+
+      json.validate[SensitiveGoodsCode] mustEqual JsSuccess(SensitiveGoodsCode("12", "description"))
+    }
+  }
+
+}

--- a/test/models/reference/TransportModeSpec.scala
+++ b/test/models/reference/TransportModeSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.reference
+import generators.ReferenceModelGenerators
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.Json
+
+class TransportModeSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks with ReferenceModelGenerators {
+
+  "TransportMode" - {
+
+    "deserialise from json to TransportMode" in {
+
+      forAll(arbitrary[TransportMode]) {
+        transportMode =>
+          val json = Json.obj("code" -> transportMode.code, "description" -> transportMode.description)
+
+          json.validate[TransportMode] mustEqual JsSuccess(transportMode)
+      }
+    }
+
+    "deserialise from json to TransportMode when code is Int" in {
+      val json = Json.obj("code" -> 12, "description" -> "description")
+
+      json.validate[TransportMode] mustEqual JsSuccess(TransportMode("12", "description"))
+    }
+  }
+
+}

--- a/test/services/ReferenceDataServiceSpec.scala
+++ b/test/services/ReferenceDataServiceSpec.scala
@@ -23,10 +23,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.client.WireMock.status
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import generators.ReferenceModelGenerators
-import models.reference.AdditionalInformation
-import models.reference.Country
-import models.reference.DocumentType
-import models.reference.KindOfPackage
+import models.reference._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
@@ -335,6 +332,337 @@ class ReferenceDataServiceSpec
               val expectedError = (JsPath, Seq(JsonValidationError("error.expected.jsarray")))
 
               result.invalidValue.toChain.toList must contain theSameElementsAs Seq(JsonError("additionalInformation", Seq(expectedError)))
+          }
+      }
+    }
+  }
+
+  "transportMode" - {
+
+    val endpoint = "/transit-movements-trader-reference-data/transport-mode"
+
+    "must return a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier], arbitrary[Seq[TransportMode]]) {
+        (hc, data) =>
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(Json.toJson(data).toString)
+              )
+          )
+
+          whenReady(service.transportMode()(implicitly, hc)) {
+            result =>
+              result.valid.value mustEqual data
+          }
+      }
+    }
+
+    "must return a Reference Data Retrieval Error" - {
+
+      "when the server returns a 4xx or 5xx status" in {
+
+        forAll(arbitrary[HeaderCarrier], errorStatuses) {
+          (hc, returnStatus) =>
+            server.stubFor(
+              get(urlEqualTo(endpoint))
+                .willReturn(
+                  status(returnStatus).withBody("body")
+                )
+            )
+
+            whenReady(service.transportMode()(implicitly, hc)) {
+              result =>
+                result.invalidValue.toChain.toList must contain theSameElementsAs Seq(ReferenceDataRetrievalError("transportMode", returnStatus, "body"))
+            }
+        }
+      }
+    }
+
+    "when the server returns data that cannot be read as a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier]) {
+        hc =>
+          val invalidJson = Json.obj("foo" -> "bar")
+
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(invalidJson.toString)
+              )
+          )
+
+          whenReady(service.transportMode()(implicitly, hc)) {
+            result =>
+              val expectedError = (JsPath, Seq(JsonValidationError("error.expected.jsarray")))
+
+              result.invalidValue.toChain.toList must contain theSameElementsAs Seq(JsonError("transportMode", Seq(expectedError)))
+          }
+      }
+    }
+  }
+
+  "controlResultCode" - {
+
+    val endpoint = "/transit-movements-trader-reference-data/control-result"
+
+    "must return a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier], arbitrary[Seq[ControlResult]]) {
+        (hc, data) =>
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(Json.toJson(data).toString)
+              )
+          )
+
+          whenReady(service.controlResult()(implicitly, hc)) {
+            result =>
+              result.valid.value mustEqual data
+          }
+      }
+    }
+
+    "must return a Reference Data Retrieval Error" - {
+
+      "when the server returns a 4xx or 5xx status" in {
+
+        forAll(arbitrary[HeaderCarrier], errorStatuses) {
+          (hc, returnStatus) =>
+            server.stubFor(
+              get(urlEqualTo(endpoint))
+                .willReturn(
+                  status(returnStatus).withBody("body")
+                )
+            )
+
+            whenReady(service.controlResult()(implicitly, hc)) {
+              result =>
+                result.invalidValue.toChain.toList must contain theSameElementsAs Seq(ReferenceDataRetrievalError("controlResult", returnStatus, "body"))
+            }
+        }
+      }
+    }
+
+    "when the server returns data that cannot be read as a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier]) {
+        hc =>
+          val invalidJson = Json.obj("foo" -> "bar")
+
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(invalidJson.toString)
+              )
+          )
+
+          whenReady(service.controlResult()(implicitly, hc)) {
+            result =>
+              val expectedError = (JsPath, Seq(JsonValidationError("error.expected.jsarray")))
+
+              result.invalidValue.toChain.toList must contain theSameElementsAs Seq(JsonError("controlResult", Seq(expectedError)))
+          }
+      }
+    }
+  }
+
+  "previousDocumentTypes" - {
+
+    val endpoint = "/transit-movements-trader-reference-data/previous-document-types"
+
+    "must return a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier], arbitrary[Seq[PreviousDocumentTypes]]) {
+        (hc, data) =>
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(Json.toJson(data).toString)
+              )
+          )
+
+          whenReady(service.previousDocumentTypes()(implicitly, hc)) {
+            result =>
+              result.valid.value mustEqual data
+          }
+      }
+    }
+
+    "must return a Reference Data Retrieval Error" - {
+
+      "when the server returns a 4xx or 5xx status" in {
+
+        forAll(arbitrary[HeaderCarrier], errorStatuses) {
+          (hc, returnStatus) =>
+            server.stubFor(
+              get(urlEqualTo(endpoint))
+                .willReturn(
+                  status(returnStatus).withBody("body")
+                )
+            )
+
+            whenReady(service.previousDocumentTypes()(implicitly, hc)) {
+              result =>
+                result.invalidValue.toChain.toList must contain theSameElementsAs Seq(
+                  ReferenceDataRetrievalError("previousDocumentTypes", returnStatus, "body"))
+            }
+        }
+      }
+    }
+
+    "when the server returns data that cannot be read as a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier]) {
+        hc =>
+          val invalidJson = Json.obj("foo" -> "bar")
+
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(invalidJson.toString)
+              )
+          )
+
+          whenReady(service.previousDocumentTypes()(implicitly, hc)) {
+            result =>
+              val expectedError = (JsPath, Seq(JsonValidationError("error.expected.jsarray")))
+
+              result.invalidValue.toChain.toList must contain theSameElementsAs Seq(JsonError("previousDocumentTypes", Seq(expectedError)))
+          }
+      }
+    }
+  }
+
+  "sensitiveGoodsCode" - {
+
+    val endpoint = "/transit-movements-trader-reference-data/sensitive-goods-code"
+
+    "must return a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier], arbitrary[Seq[SensitiveGoodsCode]]) {
+        (hc, data) =>
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(Json.toJson(data).toString)
+              )
+          )
+
+          whenReady(service.sensitiveGoodsCode()(implicitly, hc)) {
+            result =>
+              result.valid.value mustEqual data
+          }
+      }
+    }
+
+    "must return a Reference Data Retrieval Error" - {
+
+      "when the server returns a 4xx or 5xx status" in {
+
+        forAll(arbitrary[HeaderCarrier], errorStatuses) {
+          (hc, returnStatus) =>
+            server.stubFor(
+              get(urlEqualTo(endpoint))
+                .willReturn(
+                  status(returnStatus).withBody("body")
+                )
+            )
+
+            whenReady(service.sensitiveGoodsCode()(implicitly, hc)) {
+              result =>
+                result.invalidValue.toChain.toList must contain theSameElementsAs Seq(ReferenceDataRetrievalError("sensitiveGoodsCode", returnStatus, "body"))
+            }
+        }
+      }
+    }
+
+    "when the server returns data that cannot be read as a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier]) {
+        hc =>
+          val invalidJson = Json.obj("foo" -> "bar")
+
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(invalidJson.toString)
+              )
+          )
+
+          whenReady(service.sensitiveGoodsCode()(implicitly, hc)) {
+            result =>
+              val expectedError = (JsPath, Seq(JsonValidationError("error.expected.jsarray")))
+
+              result.invalidValue.toChain.toList must contain theSameElementsAs Seq(JsonError("sensitiveGoodsCode", Seq(expectedError)))
+          }
+      }
+    }
+  }
+
+  "specialMentions" - {
+
+    val endpoint = "/transit-movements-trader-reference-data/special-mentions"
+
+    "must return a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier], arbitrary[Seq[SpecialMentions]]) {
+        (hc, data) =>
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(Json.toJson(data).toString)
+              )
+          )
+
+          whenReady(service.specialMentions()(implicitly, hc)) {
+            result =>
+              result.valid.value mustEqual data
+          }
+      }
+    }
+
+    "must return a Reference Data Retrieval Error" - {
+
+      "when the server returns a 4xx or 5xx status" in {
+
+        forAll(arbitrary[HeaderCarrier], errorStatuses) {
+          (hc, returnStatus) =>
+            server.stubFor(
+              get(urlEqualTo(endpoint))
+                .willReturn(
+                  status(returnStatus).withBody("body")
+                )
+            )
+
+            whenReady(service.specialMentions()(implicitly, hc)) {
+              result =>
+                result.invalidValue.toChain.toList must contain theSameElementsAs Seq(ReferenceDataRetrievalError("specialMentions", returnStatus, "body"))
+            }
+        }
+      }
+    }
+
+    "when the server returns data that cannot be read as a sequence" in {
+
+      forAll(arbitrary[HeaderCarrier]) {
+        hc =>
+          val invalidJson = Json.obj("foo" -> "bar")
+
+          server.stubFor(
+            get(urlEqualTo(endpoint))
+              .willReturn(
+                ok(invalidJson.toString)
+              )
+          )
+
+          whenReady(service.specialMentions()(implicitly, hc)) {
+            result =>
+              val expectedError = (JsPath, Seq(JsonValidationError("error.expected.jsarray")))
+
+              result.invalidValue.toChain.toList must contain theSameElementsAs Seq(JsonError("specialMentions", Seq(expectedError)))
           }
       }
     }

--- a/test/services/XMLToTransitAccompanyingDocumentSpec.scala
+++ b/test/services/XMLToTransitAccompanyingDocumentSpec.scala
@@ -56,7 +56,10 @@ class XMLToTransitAccompanyingDocumentSpec
   private def declarationXml =
     <CC015A>
       <HEAHEA>
-        <RefNumHEA4>99IT9876AB88901209</RefNumHEA4>
+        <RefNumHEA4>LRNVALUE</RefNumHEA4>
+        <TypOfDecHEA24>T2</TypOfDecHEA24>
+          <CouOfDisCodHEA55>GB</CouOfDisCodHEA55>
+          <CouOfDesCodHEA30>IT</CouOfDesCodHEA30>
       </HEAHEA>
     </CC015A>
 }

--- a/test/services/conversion/TransitAccompanyingDocumentConversionServiceSpec.scala
+++ b/test/services/conversion/TransitAccompanyingDocumentConversionServiceSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.conversion
+import cats.data.Validated.Valid
+import cats.implicits._
+import cats.scalatest.ValidatedMatchers
+import cats.scalatest.ValidatedValues
+import models.DeclarationType
+import models.reference.Country
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.mockito.MockitoSugar
+import services.ReferenceDataNotFound
+import services.ReferenceDataRetrievalError
+import services.ReferenceDataService
+import services.ValidationResult
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class TransitAccompanyingDocumentConversionServiceSpec
+    extends FreeSpec
+    with MustMatchers
+    with MockitoSugar
+    with ValidatedMatchers
+    with ValidatedValues
+    with ScalaFutures
+    with IntegrationPatience {
+
+  private val countries = Seq(Country("valid", "AA", "Country A"), Country("valid", "BB", "Country B"))
+
+  implicit private val hc: HeaderCarrier = HeaderCarrier()
+
+  val validModel = models.TransitAccompanyingDocument(
+    localReferenceNumber = "lrn",
+    declarationType = DeclarationType.T1,
+    countryOfDispatch = Some(countries.head.code),
+    countryOfDestination = Some(countries.head.code)
+  )
+
+  "toViewModel" - {
+
+    "must return a view model" in {
+
+      val referenceDataService = mock[ReferenceDataService]
+      when(referenceDataService.countries()(any(), any())) thenReturn Future.successful(Valid(countries))
+
+      val service = new TransitAccompanyingDocumentConversionService(referenceDataService)
+
+      val expectedResult = viewmodels.tad.TransitAccompanyingDocument(
+        localReferenceNumber = "lrn",
+        declarationType = DeclarationType.T1,
+        singleCountryOfDispatch = Some(countries.head),
+        singleCountryOfDestination = Some(countries.head)
+      )
+
+      val result: ValidationResult[viewmodels.tad.TransitAccompanyingDocument] = service.toViewModel(validModel).futureValue
+
+      result.valid.value mustEqual expectedResult
+    }
+
+    "must return errors when reference data cannot be retrieved" in {
+
+      val referenceDataService = mock[ReferenceDataService]
+
+      when(referenceDataService.countries()(any(), any()))
+        .thenReturn(Future.successful(ReferenceDataRetrievalError("countries", 500, "body").invalidNec))
+
+      val service = new TransitAccompanyingDocumentConversionService(referenceDataService)
+
+      val result = service.toViewModel(validModel).futureValue
+
+      val expectedErrors = Seq(
+        ReferenceDataRetrievalError("countries", 500, "body")
+      )
+
+      result.invalidValue.toChain.toList must contain theSameElementsAs expectedErrors
+    }
+
+    "must return errors when reference data can be retrieved but the conversion fails" in {
+
+      val referenceDataService = mock[ReferenceDataService]
+      when(referenceDataService.countries()(any(), any())) thenReturn Future.successful(Valid(countries))
+
+      val service = new TransitAccompanyingDocumentConversionService(referenceDataService)
+
+      val invalidRefData = validModel copy (countryOfDispatch = Some("non-existent code"))
+
+      val result = service.toViewModel(invalidRefData).futureValue
+
+      result.invalidValue.toChain.toList must contain theSameElementsAs Seq(ReferenceDataNotFound("countryOfDispatch", "non-existent code"))
+    }
+  }
+}

--- a/test/services/conversion/TransitAccompanyingDocumentConverterSpec.scala
+++ b/test/services/conversion/TransitAccompanyingDocumentConverterSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.conversion
+import cats.scalatest.ValidatedMatchers
+import cats.scalatest.ValidatedValues
+import models.DeclarationType
+import models.reference.Country
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import services.ReferenceDataNotFound
+
+class TransitAccompanyingDocumentConverterSpec extends FreeSpec with MustMatchers with ValidatedMatchers with ValidatedValues {
+
+  private val countries = Seq(Country("valid", "AA", "Country A"), Country("valid", "BB", "Country B"))
+
+  private val invalidCode = "non-existent code"
+
+  "toViewModel" - {
+
+    "must return a view model when all of the necessary reference data can be found" in {
+
+      val model = models.TransitAccompanyingDocument(
+        localReferenceNumber = "lrn",
+        declarationType = DeclarationType.T1,
+        countryOfDispatch = Some(countries.head.code),
+        countryOfDestination = Some(countries.head.code)
+      )
+
+      val expectedResult = viewmodels.tad.TransitAccompanyingDocument(
+        localReferenceNumber = "lrn",
+        declarationType = DeclarationType.T1,
+        singleCountryOfDispatch = Some(countries.head),
+        singleCountryOfDestination = Some(countries.head)
+      )
+
+      val result = TransitAccompanyingDocumentConverter.toViewModel(model, countries)
+
+      result.valid.value mustEqual expectedResult
+    }
+
+    "must return errors when codes cannot be found in the reference data" in {
+
+      val model = models.TransitAccompanyingDocument(
+        localReferenceNumber = "lrn",
+        declarationType = DeclarationType.T1,
+        countryOfDispatch = Some(invalidCode),
+        countryOfDestination = Some(invalidCode)
+      )
+
+      val result = TransitAccompanyingDocumentConverter.toViewModel(model, countries)
+
+      val expectedErrors = Seq(
+        ReferenceDataNotFound("countryOfDispatch", invalidCode),
+        ReferenceDataNotFound("countryOfDestination", invalidCode)
+      )
+
+      result.invalidValue.toChain.toList must contain theSameElementsAs expectedErrors
+    }
+  }
+}

--- a/test/services/conversion/UnloadingPermissionConverterSpec.scala
+++ b/test/services/conversion/UnloadingPermissionConverterSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package services
+package services.conversion
 
 import java.time.LocalDate
 
@@ -28,6 +28,7 @@ import models.reference.DocumentType
 import models.reference.KindOfPackage
 import org.scalatest.FreeSpec
 import org.scalatest.MustMatchers
+import services.ReferenceDataNotFound
 
 class UnloadingPermissionConverterSpec extends FreeSpec with MustMatchers with ValidatedMatchers with ValidatedValues {
 


### PR DESCRIPTION
Added
- Additional reference data calls
- Initial TransitAccompanyingDocumentConverter
- Small updates to the model

This PR gives us the functionality needed to build the TAD view model. Follow on PRs will be raised to build out the model to represent whats needed for the TAD document (data from the IE15)