### PR TITLE
CTCTRADERS-2325 Add content disposition and content type headings to TAD, TSAD and Unloading remarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ test-result
 tmp
 .idea_modules
 bin
+.metals/
+.vscode/
+project/metals.sbt

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,5 @@
+version = "2.7.5"
+
 // Sets max amount of characters before new line
 maxColumn = 160
 

--- a/app/json/package.scala
+++ b/app/json/package.scala
@@ -16,7 +16,6 @@
 
 import cats.data.NonEmptyList
 import play.api.libs.json._
-import play.api.libs.functional.syntax._
 
 package object json {
 

--- a/app/models/ControlResult.scala
+++ b/app/models/ControlResult.scala
@@ -19,7 +19,6 @@ package models
 import cats.syntax.all._
 import com.lucidchart.open.xtract.XmlReader
 import com.lucidchart.open.xtract.__
-import utils.DateFormatter
 import utils.LocalDateXMLReader._
 
 import java.time.LocalDate

--- a/app/models/DeclarationType.scala
+++ b/app/models/DeclarationType.scala
@@ -18,7 +18,6 @@ package models
 
 import com.lucidchart.open.xtract.ParseError
 import com.lucidchart.open.xtract.ParseFailure
-import com.lucidchart.open.xtract.ParseResult
 import com.lucidchart.open.xtract.ParseSuccess
 import com.lucidchart.open.xtract.XmlReader
 

--- a/app/models/GuaranteeDetails.scala
+++ b/app/models/GuaranteeDetails.scala
@@ -17,7 +17,6 @@
 package models
 
 import cats.implicits.catsSyntaxTuple2Semigroupal
-import cats.implicits.catsSyntaxTuple5Semigroupal
 import com.lucidchart.open.xtract.XmlReader
 import com.lucidchart.open.xtract.XmlReader.strictReadSeq
 import com.lucidchart.open.xtract.__

--- a/app/services/SpecialMentionConverter.scala
+++ b/app/services/SpecialMentionConverter.scala
@@ -18,7 +18,6 @@ package services
 
 import models.reference.AdditionalInformation
 
-
 object SpecialMentionConverter extends Converter {
 
   def toViewModel(

--- a/app/services/SpecialMentionConverter.scala
+++ b/app/services/SpecialMentionConverter.scala
@@ -16,10 +16,8 @@
 
 package services
 
-import cats.data.Validated._
-import cats.implicits._
 import models.reference.AdditionalInformation
-import models.reference.Country
+
 
 object SpecialMentionConverter extends Converter {
 

--- a/app/utils/DateFormatter.scala
+++ b/app/utils/DateFormatter.scala
@@ -40,7 +40,7 @@ object DateFormatter {
       try {
         date.format(DateTimeFormatter.ofPattern(pattern))
       } catch {
-        case _ => date.toString
+        case _: Throwable => date.toString
       }
   }
 }

--- a/app/utils/FileNameSanitizer.scala
+++ b/app/utils/FileNameSanitizer.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import scala.util.matching.Regex
+
+object FileNameSanitizer extends (String => String) {
+
+  val InvalidFileNameCharacters: Regex = "[^a-zA-Z0-9]".r
+
+  override def apply(v1: String): String =
+    InvalidFileNameCharacters.replaceAllIn(v1, "x")
+
+}

--- a/app/utils/LocalDateXMLReader.scala
+++ b/app/utils/LocalDateXMLReader.scala
@@ -20,7 +20,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import com.lucidchart.open.xtract.ParseError
 import com.lucidchart.open.xtract.ParseFailure
-import com.lucidchart.open.xtract.ParseResult
 import com.lucidchart.open.xtract.ParseSuccess
 import com.lucidchart.open.xtract.XmlReader
 import utils.DateFormatter.dateFormatter

--- a/app/viewmodels/Helpers.scala
+++ b/app/viewmodels/Helpers.scala
@@ -17,8 +17,6 @@
 package viewmodels
 
 import cats.data.NonEmptyList
-import models.SecurityConsignee
-import models.SecurityConsignor
 import models.reference.Country
 
 object Helpers {

--- a/test/controllers/SpecBase.scala
+++ b/test/controllers/SpecBase.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatest.OptionValues
+import org.scalatestplus.mockito.MockitoSugar
+
+trait SpecBase extends FreeSpec with MustMatchers with OptionValues with MockitoSugar

--- a/test/controllers/TransitAccompanyingDocumentControllerSpec.scala
+++ b/test/controllers/TransitAccompanyingDocumentControllerSpec.scala
@@ -42,6 +42,7 @@ import services.conversion.TransitAccompanyingDocumentConversionService
 import services.pdf.UnloadingPermissionPdfGenerator
 
 import scala.concurrent.Future
+import play.api.http.MimeTypes
 
 class TransitAccompanyingDocumentControllerSpec
     extends FreeSpec
@@ -89,6 +90,8 @@ class TransitAccompanyingDocumentControllerSpec
             val result = route(application, request).value
 
             status(result) mustEqual OK
+            headers(result).get(CONTENT_TYPE).value mustEqual "application/pdf"
+            headers(result).get(CONTENT_DISPOSITION).value mustEqual """attachment; filename="TAD_MRNVALUE.pdf""""
         }
       }
     }

--- a/test/controllers/TransitSecurityAccompanyingDocumentControllerSpec.scala
+++ b/test/controllers/TransitSecurityAccompanyingDocumentControllerSpec.scala
@@ -90,6 +90,8 @@ class TransitSecurityAccompanyingDocumentControllerSpec
             val result = route(application, request).value
 
             status(result) mustEqual OK
+            headers(result).get(CONTENT_TYPE).value mustEqual "application/pdf"
+            headers(result).get(CONTENT_DISPOSITION).value mustEqual """attachment; filename="TSAD_MRNVALUE.pdf""""
         }
       }
     }

--- a/test/controllers/UnloadingPermissionControllerSpec.scala
+++ b/test/controllers/UnloadingPermissionControllerSpec.scala
@@ -89,6 +89,8 @@ class UnloadingPermissionControllerSpec
             val result = route(application, request).value
 
             status(result) mustEqual OK
+            headers(result).get(CONTENT_TYPE).value mustEqual "application/pdf"
+            headers(result).get(CONTENT_DISPOSITION).value mustEqual """attachment; filename="UnloadingPermission_99IT9876AB88901209.pdf""""
         }
       }
     }

--- a/test/generators/ReferenceModelGenerators.scala
+++ b/test/generators/ReferenceModelGenerators.scala
@@ -21,8 +21,6 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 
-import java.time.LocalDate
-
 trait ReferenceModelGenerators extends GeneratorHelpers {
 
   implicit lazy val arbitraryCountry: Arbitrary[Country] =

--- a/test/models/SecurityConsignorSpec.scala
+++ b/test/models/SecurityConsignorSpec.scala
@@ -24,8 +24,6 @@ import org.scalatest.MustMatchers
 import org.scalatest.OptionValues
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import scala.xml.NodeSeq
-
 class SecurityConsignorSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks with ModelGenerators with OptionValues {
 
   "SecurityConsignor XML" - {

--- a/test/services/GoodsItemConverterSpec.scala
+++ b/test/services/GoodsItemConverterSpec.scala
@@ -25,8 +25,6 @@ import models.reference.DocumentType
 import models.reference.KindOfPackage
 import org.scalatest.FreeSpec
 import org.scalatest.MustMatchers
-import viewmodels.Consignee
-import viewmodels.Consignor
 
 class GoodsItemConverterSpec extends FreeSpec with MustMatchers with ValidatedMatchers with ValidatedValues {
 

--- a/test/services/conversion/TransitAccompanyingDocumentConverterSpec.scala
+++ b/test/services/conversion/TransitAccompanyingDocumentConverterSpec.scala
@@ -27,9 +27,6 @@ import models.Header
 import models.Itinerary
 import models.PreviousAdministrativeReference
 import models.ReturnCopiesCustomsOffice
-import models.SafetyAndSecurityCarrier
-import models.SecurityConsignee
-import models.SecurityConsignor
 import models.reference.AdditionalInformation
 import models.reference.ControlResultData
 import models.reference.Country

--- a/test/services/pdf/UnloadingPermissionPdfGeneratorSpec.scala
+++ b/test/services/pdf/UnloadingPermissionPdfGeneratorSpec.scala
@@ -33,7 +33,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Environment
 import services.pdf.UnloadingPermissionPdfGeneratorConstants.permissionToUnloadViewModel
-import uk.gov.hmrc.http.HeaderCarrier
 import viewmodels._
 
 import java.nio.file.Files
@@ -49,7 +48,6 @@ class UnloadingPermissionPdfGeneratorSpec
     with ScalaFutures {
 
   private lazy val service: UnloadingPermissionPdfGenerator = app.injector.instanceOf[UnloadingPermissionPdfGenerator]
-  implicit private val hc: HeaderCarrier                    = HeaderCarrier()
   val env: Environment                                      = app.injector.instanceOf[Environment]
 
   "UnloadingPermissionPdfGenerator" - {

--- a/test/utils/FileNameSanitizerSpec.scala
+++ b/test/utils/FileNameSanitizerSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import base.SpecBase
+
+class FileNameSanitizerSpec extends SpecBase {
+
+  "when there all the characters are valid" - {
+    "returns the full input" in {
+      val testString = "asdfasdf"
+
+      val fileName = FileNameSanitizer(testString)
+
+      fileName mustEqual testString
+    }
+  }
+
+  "when there is a character that is invalid" - {
+    "the string returned has `x` in place of the invalid character" - {
+
+      "when the string contains only characters that match the filters" in {
+        val testString = "<<>><>"
+
+        val fileName = FileNameSanitizer(testString)
+
+        fileName mustEqual "xxxxxx"
+      }
+
+      "when the string contains some characters that match the filters" in {
+        val testString = "ab<12AZ>40"
+
+        val fileName = FileNameSanitizer(testString)
+
+        fileName mustEqual "abx12AZx40"
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
- CTCTRADERS-2325 Ignore vscode, metals and bloop config files
- CTCTRADERS-2325 Resolve compiler warnings
- CTCTRADERS-2325 Add base trait for tests
- CTCTRADERS-2325 Add utility to remove invalid characters for a filename.
- CTCTRADERS-2325 Add scalafmt version
- CTCTRADERS-2325 Add content disposition and content type headings to TAD, TSAD and Unloading remarks
