### PR TITLE
Use consistent exception handling and ensure exception traces are logged

### DIFF
--- a/app/controllers/TransitAccompanyingDocumentController.scala
+++ b/app/controllers/TransitAccompanyingDocumentController.scala
@@ -19,6 +19,7 @@ package controllers
 import cats.data.Validated
 import com.lucidchart.open.xtract.ParseFailure
 import com.lucidchart.open.xtract.ParseSuccess
+import com.lucidchart.open.xtract.PartialParseSuccess
 import logging.Logging
 import play.api.mvc.Action
 import play.api.mvc.ControllerComponents
@@ -46,23 +47,30 @@ class TransitAccompanyingDocumentController @Inject() (
     implicit request =>
       XMLToReleaseForTransit.convert(request.body) match {
         case ParseSuccess(transitAccompanyingDocument) =>
-          conversionService.toViewModel(transitAccompanyingDocument).map {
-            case Validated.Valid(viewModel) =>
-              val fileName = s"TAD_${FileNameSanitizer(transitAccompanyingDocument.header.movementReferenceNumber)}.pdf"
-              Ok(pdf.generate(viewModel))
-                .withHeaders(
-                  CONTENT_TYPE        -> "application/pdf",
-                  CONTENT_DISPOSITION -> s"""attachment; filename="$fileName""""
-                )
-            case Validated.Invalid(errors) =>
-              logger.info(s"Failed to convert to TransitAccompanyingDocumentController with following errors: $errors")
-              InternalServerError
-          } recover {
-            case NonFatal(e) =>
-              logger.error("Exception thrown while converting to TransitAccompanyingDocument", e)
-              BadGateway
-          }
+          conversionService
+            .toViewModel(transitAccompanyingDocument)
+            .map {
+              case Validated.Valid(viewModel) =>
+                val fileName = s"TAD_${FileNameSanitizer(transitAccompanyingDocument.header.movementReferenceNumber)}.pdf"
+                Ok(pdf.generate(viewModel))
+                  .withHeaders(
+                    CONTENT_TYPE        -> "application/pdf",
+                    CONTENT_DISPOSITION -> s"""attachment; filename="$fileName""""
+                  )
+              case Validated.Invalid(errors) =>
+                logger.error(s"Failed to convert to TransitAccompanyingDocumentController with following errors: $errors")
+                InternalServerError
+            }
+            .recover {
+              case NonFatal(e) =>
+                logger.error("Exception thrown while converting to TransitAccompanyingDocument", e)
+                BadGateway
+            }
+        case PartialParseSuccess(result, errors) =>
+          logger.warn(s"Partially failed to parse xml to TransitAccompanyingDocument with the following errors: $errors and result $result")
+          Future.successful(BadRequest)
         case ParseFailure(errors) =>
+          logger.error(s"Failed to parse xml to TransitAccompanyingDocument with the following errors: $errors")
           Future.successful(BadRequest(s"Failed to parse xml to TransitAccompanyingDocument with the following errors: $errors"))
       }
   }

--- a/app/controllers/TransitAccompanyingDocumentController.scala
+++ b/app/controllers/TransitAccompanyingDocumentController.scala
@@ -26,12 +26,13 @@ import services._
 import services.conversion.TransitAccompanyingDocumentConversionService
 import services.pdf.TADPdfGenerator
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import utils.FileNameSanitizer
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 import scala.xml.NodeSeq
-import utils.FileNameSanitizer
 
 class TransitAccompanyingDocumentController @Inject() (
   conversionService: TransitAccompanyingDocumentConversionService,
@@ -57,8 +58,8 @@ class TransitAccompanyingDocumentController @Inject() (
               logger.info(s"Failed to convert to TransitAccompanyingDocumentController with following errors: $errors")
               InternalServerError
           } recover {
-            case e =>
-              logger.info(s"Exception thrown while converting to TransitAccompanyingDocumentController: ${e.getMessage}")
+            case NonFatal(e) =>
+              logger.error("Exception thrown while converting to TransitAccompanyingDocument", e)
               BadGateway
           }
         case ParseFailure(errors) =>

--- a/app/controllers/TransitAccompanyingDocumentController.scala
+++ b/app/controllers/TransitAccompanyingDocumentController.scala
@@ -67,7 +67,7 @@ class TransitAccompanyingDocumentController @Inject() (
                 BadGateway
             }
         case PartialParseSuccess(result, errors) =>
-          logger.warn(s"Partially failed to parse xml to TransitAccompanyingDocument with the following errors: $errors and result $result")
+          logger.error(s"Partially failed to parse xml to TransitAccompanyingDocument with the following errors: $errors and result $result")
           Future.successful(BadRequest)
         case ParseFailure(errors) =>
           logger.error(s"Failed to parse xml to TransitAccompanyingDocument with the following errors: $errors")

--- a/app/controllers/TransitSecurityAccompanyingDocumentController.scala
+++ b/app/controllers/TransitSecurityAccompanyingDocumentController.scala
@@ -27,12 +27,13 @@ import services.XMLToReleaseForTransit
 import services.conversion.TransitSecurityAccompanyingDocumentConversionService
 import services.pdf.TSADPdfGenerator
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import utils.FileNameSanitizer
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 import scala.xml.NodeSeq
-import utils.FileNameSanitizer
 
 class TransitSecurityAccompanyingDocumentController @Inject() (
   conversionService: TransitSecurityAccompanyingDocumentConversionService,
@@ -58,8 +59,8 @@ class TransitSecurityAccompanyingDocumentController @Inject() (
               logger.info(s"Failed to convert to TransitSecurityAccompanyingDocument with following errors: $errors")
               InternalServerError
           } recover {
-            case e =>
-              logger.info(s"Exception thrown while converting to TransitSecurityAccompanyingDocument: ${e.getMessage}")
+            case NonFatal(e) =>
+              logger.error("Exception thrown while converting to TransitSecurityAccompanyingDocument", e)
               BadGateway
           }
         case PartialParseSuccess(result, errors) =>

--- a/app/controllers/TransitSecurityAccompanyingDocumentController.scala
+++ b/app/controllers/TransitSecurityAccompanyingDocumentController.scala
@@ -56,7 +56,7 @@ class TransitSecurityAccompanyingDocumentController @Inject() (
                   CONTENT_DISPOSITION -> s"""attachment; filename="$fileName""""
                 )
             case Validated.Invalid(errors) =>
-              logger.info(s"Failed to convert to TransitSecurityAccompanyingDocument with following errors: $errors")
+              logger.error(s"Failed to convert to TransitSecurityAccompanyingDocument with following errors: $errors")
               InternalServerError
           } recover {
             case NonFatal(e) =>
@@ -64,10 +64,10 @@ class TransitSecurityAccompanyingDocumentController @Inject() (
               BadGateway
           }
         case PartialParseSuccess(result, errors) =>
-          logger.info(s"Partially failed to parse xml to TransitSecurityAccompanyingDocument with the following errors: $errors and result $result")
+          logger.error(s"Partially failed to parse xml to TransitSecurityAccompanyingDocument with the following errors: $errors and result $result")
           Future.successful(BadRequest)
         case ParseFailure(errors) =>
-          logger.info(s"Failed to parse xml to TransitSecurityAccompanyingDocument with the following errors: $errors")
+          logger.error(s"Failed to parse xml to TransitSecurityAccompanyingDocument with the following errors: $errors")
           Future.successful(BadRequest)
       }
   }


### PR DESCRIPTION
To investigate 502 errors experienced when running the perf tests - this changes each endpoint to do the same error handling and ensures that the full exception trace is logged by using the `logger.error(String, Throwable)` method.