### PR TITLE
CTCP-1113 | Update sbt-auto-build for compatibility with Java 11

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 


### PR DESCRIPTION
In order to migrate this repo to Java 11 the following activities were required;

Update to latest `sbt-auto-build` library. 

Install a Java 11 JDK in IntelliJ. 

![Screenshot 2022-09-13 at 15 47 54](https://user-images.githubusercontent.com/40767309/189933041-682cde3a-c6c1-487a-b694-6e45af2211ef.png)

Install `jEnv` [locally](https://github.com/jenv/jenv) to allow the switching of java versions locally. This is required when running `sbt` from the command line to ensure the desired Java version is used.

Install Java 11 locally and switch to it when running this repo or running the tests. This ensures that we are running the same version of Java locally as to what will be running in Jenkins after we update build jobs.

Link to build jobs changes [here](https://github.com/hmrc/build-jobs/pull/11498)

