### PR TITLE
Fix optionality of GoodsMeasure and Representative fields, to match with current XSDs

### DIFF
--- a/app/models/P5/departure/Commodity.scala
+++ b/app/models/P5/departure/Commodity.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.OFormat
 case class Commodity(
   descriptionOfGoods: String,
   CommodityCode: Option[CommodityCode],
-  GoodsMeasure: GoodsMeasure,
+  GoodsMeasure: Option[GoodsMeasure],
   cusCode: Option[String],
   DangerousGoods: Option[List[DangerousGoods]]
 )

--- a/app/models/P5/departure/ConsignmentItem.scala
+++ b/app/models/P5/departure/ConsignmentItem.scala
@@ -62,8 +62,8 @@ case class ConsignmentItem(
   val additionalReferenceString: String   = AdditionalReference.map(_.showAll).getOrElse("")
   val additionalInformationString: String = AdditionalInformation.map(_.showAll).getOrElse("")
 
-  val grossMass: String          = Commodity.GoodsMeasure.grossMass.toString
-  val netMass: String            = Commodity.GoodsMeasure.netMass.getOrElse("").toString
+  val grossMass: String          = Commodity.GoodsMeasure.map(_.grossMass.toString).getOrElse("")
+  val netMass: String            = Commodity.GoodsMeasure.flatMap(_.netMass.map(_.toString)).getOrElse("")
   val consignorId: String        = Consignor.flatMap(_.identificationNumber).getOrElse("")
   val consigneeId: String        = Consignee.flatMap(_.identificationNumber).getOrElse("")
   val supplyChainActorId: String = AdditionalSupplyChainActor.map(_.map(_.identificationNumber).mkString("; ")).getOrElse("")

--- a/app/models/P5/departure/DepartureMessageData.scala
+++ b/app/models/P5/departure/DepartureMessageData.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Writes
 case class DepartureMessageData(
   TransitOperation: TransitOperation,
   HolderOfTheTransitProcedure: HolderOfTransitProcedure,
-  Representative: Representative,
+  Representative: Option[Representative],
   Consignment: Consignment,
   Guarantee: Option[List[Guarantee]],
   Authorisation: Option[List[Authorisation]],

--- a/app/models/P5/unloading/Commodity.scala
+++ b/app/models/P5/unloading/Commodity.scala
@@ -24,7 +24,7 @@ case class Commodity(
   cusCode: Option[String],
   CommodityCode: Option[CommodityCode],
   DangerousGoods: Option[Seq[DangerousGoods]],
-  GoodsMeasure: GoodsMeasure
+  GoodsMeasure: Option[GoodsMeasure]
 )
 
 object Commodity {

--- a/app/models/P5/unloading/ConsignmentItem.scala
+++ b/app/models/P5/unloading/ConsignmentItem.scala
@@ -53,8 +53,8 @@ case class ConsignmentItem(
 
   val commodityCode: String = Commodity.CommodityCode.map(_.toString).getOrElse("")
 
-  val grossMass: String = Commodity.GoodsMeasure.grossMass.toString()
-  val netMass: String   = Commodity.GoodsMeasure.netMass.map(_.toString()).getOrElse("")
+  val grossMass: String = Commodity.GoodsMeasure.map(_.grossMass.toString()).getOrElse("")
+  val netMass: String   = Commodity.GoodsMeasure.flatMap(_.netMass.map(_.toString())).getOrElse("")
 
   val cOfDest: String = countryOfDestination.getOrElse("")
 }

--- a/app/viewmodels/P5/TableViewModel.scala
+++ b/app/viewmodels/P5/TableViewModel.scala
@@ -95,9 +95,9 @@ case class Table1ViewModel(implicit ie029Data: IE029Data) {
   val holderOfTransitProcedure: String                     = truncate(150, ie029Data.data.HolderOfTheTransitProcedure.toString)
   val holderOfTransitProcedureIdentificationNumber: String = truncate(20, ie029Data.data.HolderOfTheTransitProcedure.identificationNumber.getOrElse(""))
 
-  val representative: String = ie029Data.data.Representative.toString
+  val representative: String = ie029Data.data.Representative.map(_.toString).getOrElse("")
 
-  val representativeIdentificationNumber: String = truncate(20, ie029Data.data.Representative.identificationNumber.getOrElse(""))
+  val representativeIdentificationNumber: String = truncate(20, ie029Data.data.Representative.flatMap(_.identificationNumber).getOrElse(""))
   val lrn: String                                = truncate(20, ie029Data.data.TransitOperation.LRN)
   val tir: String                                = truncate(20, ie029Data.data.TransitOperation.TIRCarnetNumber.getOrElse(""))
 

--- a/test/base/DepartureData.scala
+++ b/test/base/DepartureData.scala
@@ -92,7 +92,7 @@ trait DepartureData {
   val goodsMeasure: GoodsMeasure                                   = GoodsMeasure(1.2, Some(1.4))
   val transportCharges: TransportCharges                           = TransportCharges(Some("payPal"))
   val dangerousGoods: DangerousGoods                               = DangerousGoods("seq1", Some("UNNumber1"))
-  val commodity: Commodity                                         = Commodity("Tiles", Some(commodityCode), goodsMeasure, Some("CUSTCODE1"), Some(List(dangerousGoods)))
+  val commodity: Commodity                                         = Commodity("Tiles", Some(commodityCode), Some(goodsMeasure), Some("CUSTCODE1"), Some(List(dangerousGoods)))
 
   val consignmentItem1: ConsignmentItem = ConsignmentItem(
     Some("1T1"),
@@ -182,7 +182,7 @@ trait DepartureData {
     DepartureMessageData(
       transitOperation,
       holderOfTheTransitProcedure,
-      representative,
+      Some(representative),
       consigmment,
       Some(List(guarantee)),
       Some(List(authorisation)),

--- a/test/base/UnloadingData.scala
+++ b/test/base/UnloadingData.scala
@@ -61,7 +61,7 @@ trait UnloadingData {
   val additionalInformation: List[AdditionalInformation] = List(AdditionalInformation("32", Some("additional ref text")))
 
   val goodsMeasure: GoodsMeasure = GoodsMeasure(10.5, None)
-  val commodity: Commodity       = Commodity("commodity desc", None, None, None, goodsMeasure)
+  val commodity: Commodity       = Commodity("commodity desc", None, None, None, Some(goodsMeasure))
 
   val houseConsignment: Seq[HouseConsignment] = Seq(
     HouseConsignment(Seq(ConsignmentItem("1", 1, None, None, None, commodity, Seq(Packaging("package type", Some(3), None)), None, None, None, None, None)))

--- a/test/connectors/UnloadingPermissionP5ConnectorSpec.scala
+++ b/test/connectors/UnloadingPermissionP5ConnectorSpec.scala
@@ -16,7 +16,6 @@
 
 package connectors
 
-import base.DepartureData
 import base.SpecBase
 import base.UnloadingData
 import cats.scalatest.ValidatedMatchers

--- a/test/models/P5/unloading/ConsignmentItemSpec.scala
+++ b/test/models/P5/unloading/ConsignmentItemSpec.scala
@@ -54,9 +54,11 @@ class ConsignmentItemSpec extends SpecBase {
           DangerousGoods("UN number 2")
         )
       ),
-      GoodsMeasure = GoodsMeasure(
-        grossMass = BigDecimal(123),
-        netMass = Some(BigDecimal(456))
+      GoodsMeasure = Some(
+        GoodsMeasure(
+          grossMass = BigDecimal(123),
+          netMass = Some(BigDecimal(456))
+        )
       )
     ),
     Packaging = Seq(


### PR DESCRIPTION
Was writing a small PoC to connect our API with document generation and got errors when trying to generate a TAD as `GoodsMeasure` (important for transition!) and `Representative` are actually optional in the XSDs, and we weren't providing them.

If you have these fixes or whatever in progress, please feel free to ignore this.