### PR TITLE
Bumped batik-bridge version. This automatically pulls in xmlgraphics-…

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -33,6 +33,6 @@ object AppDependencies {
   val overrides: Seq[ModuleID] = Seq(
     "org.typelevel"          %% "cats-core"           % catsVersion,
     "org.typelevel"          %% "cats-kernel"         % catsVersion,
-    "org.apache.xmlgraphics" %  "xmlgraphics-commons" % "2.7"
+    "org.apache.xmlgraphics" %  "batik-bridge"        % "1.17"
   )
 }


### PR DESCRIPTION
Overriding batik-bridge version from 1.9 to 1.17. This:
- pulls in xmlgraphics-commons 2.9
- removes xalan