### PR TITLE
Re-adding consignor and departure transport means to TLOI.

### DIFF
--- a/app/refactor/viewmodels/p5/package.scala
+++ b/app/refactor/viewmodels/p5/package.scala
@@ -31,7 +31,7 @@ package object p5 {
       *  Therefore we need to roll these back down here.
       */
     val consignmentItems: Seq[ConsignmentItemType03] =
-      value.rollDown.Consignment.HouseConsignment
+      rollDown.Consignment.HouseConsignment
         .flatMap(_.ConsignmentItem)
 
     def rollDown: CC029CType = {

--- a/app/refactor/viewmodels/p5/package.scala
+++ b/app/refactor/viewmodels/p5/package.scala
@@ -30,10 +30,6 @@ package object p5 {
       *
       *  Therefore we need to roll these back down here.
       */
-    val consignmentItems: Seq[ConsignmentItemType03] =
-      rollDown.Consignment.HouseConsignment
-        .flatMap(_.ConsignmentItem)
-
     def rollDown: CC029CType = {
       val houseConsignments = value.Consignment.HouseConsignment
         .map {
@@ -56,6 +52,10 @@ package object p5 {
       val consignment = value.Consignment.copy(HouseConsignment = houseConsignments)
       value.copy(Consignment = consignment)
     }
+
+    val consignmentItems: Seq[ConsignmentItemType03] =
+      value.Consignment.HouseConsignment
+        .flatMap(_.ConsignmentItem)
 
     val numberOfItems: Int = consignmentItems.size
 

--- a/app/refactor/viewmodels/p5/package.scala
+++ b/app/refactor/viewmodels/p5/package.scala
@@ -31,20 +31,35 @@ package object p5 {
       *  Therefore we need to roll these back down here.
       */
     val consignmentItems: Seq[ConsignmentItemType03] =
-      value.Consignment.HouseConsignment
+      value
+        .rollDown
+        .Consignment
+        .HouseConsignment
         .flatMap(_.ConsignmentItem)
-        .rollDown(value.Consignment.TransportCharges)(
-          TransportCharges => _.copy(TransportCharges = Some(TransportCharges))
-        )
-        .rollDown(value.Consignment.referenceNumberUCR)(
-          referenceNumberUCR => _.copy(referenceNumberUCR = Some(referenceNumberUCR))
-        )
-        .rollDown(value.Consignment.countryOfDispatch)(
-          countryOfDispatch => _.copy(countryOfDispatch = Some(countryOfDispatch))
-        )
-        .rollDown(value.Consignment.countryOfDestination)(
-          countryOfDestination => _.copy(countryOfDestination = Some(countryOfDestination))
-        )
+
+    def rollDown: CC029CType = {
+      val houseConsignments = value.Consignment.HouseConsignment
+        .map {
+          houseConsignment =>
+            houseConsignment.copy(ConsignmentItem =
+              houseConsignment.ConsignmentItem
+                .rollDown(value.Consignment.TransportCharges)(
+                  TransportCharges => _.copy(TransportCharges = Some(TransportCharges))
+                )
+                .rollDown(value.Consignment.referenceNumberUCR)(
+                  referenceNumberUCR => _.copy(referenceNumberUCR = Some(referenceNumberUCR))
+                )
+                .rollDown(value.Consignment.countryOfDispatch)(
+                  countryOfDispatch => _.copy(countryOfDispatch = Some(countryOfDispatch))
+                )
+                .rollDown(value.Consignment.countryOfDestination)(
+                  countryOfDestination => _.copy(countryOfDestination = Some(countryOfDestination))
+                )
+            )
+        }
+      val consignment = value.Consignment.copy(HouseConsignment = houseConsignments)
+      value.copy(Consignment = consignment)
+    }
 
     val numberOfItems: Int = consignmentItems.size
 

--- a/app/refactor/viewmodels/p5/package.scala
+++ b/app/refactor/viewmodels/p5/package.scala
@@ -31,31 +31,27 @@ package object p5 {
       *  Therefore we need to roll these back down here.
       */
     val consignmentItems: Seq[ConsignmentItemType03] =
-      value
-        .rollDown
-        .Consignment
-        .HouseConsignment
+      value.rollDown.Consignment.HouseConsignment
         .flatMap(_.ConsignmentItem)
 
     def rollDown: CC029CType = {
       val houseConsignments = value.Consignment.HouseConsignment
         .map {
           houseConsignment =>
-            houseConsignment.copy(ConsignmentItem =
-              houseConsignment.ConsignmentItem
-                .rollDown(value.Consignment.TransportCharges)(
-                  TransportCharges => _.copy(TransportCharges = Some(TransportCharges))
-                )
-                .rollDown(value.Consignment.referenceNumberUCR)(
-                  referenceNumberUCR => _.copy(referenceNumberUCR = Some(referenceNumberUCR))
-                )
-                .rollDown(value.Consignment.countryOfDispatch)(
-                  countryOfDispatch => _.copy(countryOfDispatch = Some(countryOfDispatch))
-                )
-                .rollDown(value.Consignment.countryOfDestination)(
-                  countryOfDestination => _.copy(countryOfDestination = Some(countryOfDestination))
-                )
-            )
+            val consignmentItems = houseConsignment.ConsignmentItem
+              .rollDown(value.Consignment.TransportCharges)(
+                TransportCharges => _.copy(TransportCharges = Some(TransportCharges))
+              )
+              .rollDown(value.Consignment.referenceNumberUCR)(
+                referenceNumberUCR => _.copy(referenceNumberUCR = Some(referenceNumberUCR))
+              )
+              .rollDown(value.Consignment.countryOfDispatch)(
+                countryOfDispatch => _.copy(countryOfDispatch = Some(countryOfDispatch))
+              )
+              .rollDown(value.Consignment.countryOfDestination)(
+                countryOfDestination => _.copy(countryOfDestination = Some(countryOfDestination))
+              )
+            houseConsignment.copy(ConsignmentItem = consignmentItems)
         }
       val consignment = value.Consignment.copy(HouseConsignment = houseConsignments)
       value.copy(Consignment = consignment)

--- a/app/refactor/viewmodels/p5/tad/ConsignmentItemViewModel.scala
+++ b/app/refactor/viewmodels/p5/tad/ConsignmentItemViewModel.scala
@@ -17,6 +17,7 @@
 package refactor.viewmodels.p5.tad
 
 import generated.p5.ConsignmentItemType03
+import generated.p5.HouseConsignmentType03
 import refactor.viewmodels._
 import refactor.viewmodels.p5._
 
@@ -29,6 +30,8 @@ case class ConsignmentItemViewModel(
   supportingDocuments: String,
   consignee: String,
   consigneeId: String,
+  consignor: String,
+  consignorId: String,
   additionalReferences: String,
   additionalInformation: String,
   additionalSupplyChainActors: String,
@@ -36,6 +39,7 @@ case class ConsignmentItemViewModel(
   transportDocuments: String,
   referenceNumberUCR: String,
   grossMass: String,
+  departureTransportMeans: String,
   commodityCode: String,
   netMass: String,
   dangerousGoods: String,
@@ -48,7 +52,7 @@ case class ConsignmentItemViewModel(
 
 object ConsignmentItemViewModel {
 
-  def apply(consignmentItem: ConsignmentItemType03): ConsignmentItemViewModel =
+  def apply(houseConsignment: HouseConsignmentType03, consignmentItem: ConsignmentItemType03): ConsignmentItemViewModel =
     new ConsignmentItemViewModel(
       declarationGoodsItemNumber = consignmentItem.declarationGoodsItemNumber.toString(),
       goodsItemNumber = consignmentItem.goodsItemNumber,
@@ -56,8 +60,10 @@ object ConsignmentItemViewModel {
       descriptionOfGoods = consignmentItem.Commodity.descriptionOfGoods,
       previousDocuments = consignmentItem.PreviousDocument.map(_.asString).semiColonSeparate,
       supportingDocuments = consignmentItem.SupportingDocument.map(_.asString).semiColonSeparate,
-      consignee = consignmentItem.Consignee.map(_.asString).orElseBlank,
-      consigneeId = consignmentItem.Consignee.flatMap(_.identificationNumber).orElseBlank,
+      consignee = houseConsignment.Consignee.map(_.asString).orElseBlank,
+      consigneeId = houseConsignment.Consignee.flatMap(_.identificationNumber).orElseBlank,
+      consignor = houseConsignment.Consignor.map(_.asString).orElseBlank,
+      consignorId = houseConsignment.Consignor.flatMap(_.identificationNumber).orElseBlank,
       additionalReferences = consignmentItem.AdditionalReference.map(_.asString).semiColonSeparate,
       additionalInformation = consignmentItem.AdditionalInformation.map(_.asString).semiColonSeparate,
       additionalSupplyChainActors = consignmentItem.AdditionalSupplyChainActor.map(_.asString).semiColonSeparate,
@@ -65,6 +71,7 @@ object ConsignmentItemViewModel {
       transportDocuments = consignmentItem.TransportDocument.map(_.asString).semiColonSeparate,
       referenceNumberUCR = consignmentItem.referenceNumberUCR.orElseBlank,
       grossMass = consignmentItem.Commodity.GoodsMeasure.map(_.grossMass.asString).orElseBlank,
+      departureTransportMeans = houseConsignment.DepartureTransportMeans.map(_.asString).semiColonSeparate,
       commodityCode = consignmentItem.Commodity.CommodityCode.map(_.asString).orElseBlank,
       netMass = consignmentItem.Commodity.GoodsMeasure.flatMap(_.netMass.map(_.asString)).orElseBlank,
       dangerousGoods = consignmentItem.Commodity.DangerousGoods.map(_.asString).semiColonSeparate,

--- a/app/refactor/viewmodels/p5/tad/P5TadPdfViewModel.scala
+++ b/app/refactor/viewmodels/p5/tad/P5TadPdfViewModel.scala
@@ -35,7 +35,9 @@ object P5TadPdfViewModel {
   def apply(ie029: CC029CType): P5TadPdfViewModel =
     new P5TadPdfViewModel(
       mrn = ie029.TransitOperation.MRN,
-      consignmentItemViewModels = ie029.consignmentItems.map(ConsignmentItemViewModel(_)),
+      consignmentItemViewModels = ie029.rollDown.Consignment.HouseConsignment.flatMap {
+        houseConsignment => houseConsignment.ConsignmentItem.map(ConsignmentItemViewModel(houseConsignment, _))
+      },
       table1ViewModel = Table1ViewModel(ie029),
       table2ViewModel = Table2ViewModel(ie029),
       table4ViewModel = Table4ViewModel(ie029)

--- a/app/refactor/views/p5/tad/components/items/row_2.scala.xml
+++ b/app/refactor/views/p5/tad/components/items/row_2.scala.xml
@@ -1,11 +1,43 @@
 @(
-        previousDocuments: String,
-        supportingDocuments: String
+    consignor: String,
+    consignorId: String,
+    previousDocuments: String,
+    supportingDocuments: String
 )
 
 <fo:table-row height="8mm">
 
+    <fo:table-cell border-left-style="solid" border-left-width="1pt" border-left-color="black"
+                   border-right-style="solid" border-right-width="1pt" border-right-color="black"
+                   border-top-style="solid" border-top-width="1pt" border-top-color="black" border-bottom-style="solid"
+                   border-bottom-width="1pt" border-bottom-color="black">
+        <fo:block>
+            <fo:table width="100%">
+                <fo:table-column column-number="1" column-width="44mm"/>
+                <fo:table-column column-number="2" column-width="8mm"/>
+                <fo:table-column column-number="3" column-width="37mm"/>
+                <fo:table-body>
+                    <fo:table-row height="2mm">
+                        <fo:table-cell display-align="center" margin-left="0.5mm">
+                            <fo:block>Consignor [13 02]</fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell display-align="center" margin-left="1mm">
+                            <fo:block>ID</fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
 
+                    <fo:table-row height="6mm">
+                        <fo:table-cell margin-left="0.5mm">
+                            <fo:block>@consignor</fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell number-columns-spanned="2" margin-left="0.5mm">
+                            <fo:block>@consignorId</fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
+                </fo:table-body>
+            </fo:table>
+        </fo:block>
+    </fo:table-cell>
     <fo:table-cell border-left-style="solid" border-left-width="1pt" border-left-color="black"
                    border-right-style="solid" border-right-width="1pt" border-right-color="black"
                    border-top-style="solid" border-top-width="1pt" border-top-color="black" border-bottom-style="solid"

--- a/app/refactor/views/p5/tad/components/items/row_5.scala.xml
+++ b/app/refactor/views/p5/tad/components/items/row_5.scala.xml
@@ -1,11 +1,35 @@
 @(
-        commodityCode: String,
-        netMass: String
+    departureTransportMeans: String,
+    commodityCode: String,
+    netMass: String
 )
 
 <fo:table-row height="4mm">
 
+    <fo:table-cell border-left-style="solid" border-left-width="1pt" border-left-color="black"
+                   border-right-style="solid" border-right-width="1pt" border-right-color="black"
+                   border-top-style="solid" border-top-width="1pt" border-top-color="black" border-bottom-style="solid"
+                   border-bottom-width="1pt" border-bottom-color="black">
+        <fo:block>
+            <fo:table width="100%" table-layout="fixed">
+                <fo:table-body>
+                    <fo:table-row height="2mm">
+                        <fo:table-cell display-align="center" margin-left="0.5mm">
+                            <fo:block>Departure transport means [19 05]</fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
 
+                    <fo:table-row>
+                        <fo:table-cell margin-left="0.5mm">
+                            <fo:block-container height="2mm" overflow="hidden">
+                                <fo:block>@departureTransportMeans</fo:block>
+                            </fo:block-container>
+                        </fo:table-cell>
+                    </fo:table-row>
+                </fo:table-body>
+            </fo:table>
+        </fo:block>
+    </fo:table-cell>
     <fo:table-cell border-left-style="solid" border-left-width="1pt" border-left-color="black"
                    border-right-style="solid" border-right-width="1pt" border-right-color="black"
                    border-top-style="solid" border-top-width="1pt" border-top-color="black" border-bottom-style="solid"

--- a/app/refactor/views/p5/tad/components/items/table.scala.xml
+++ b/app/refactor/views/p5/tad/components/items/table.scala.xml
@@ -15,6 +15,8 @@
     )
 
     @row_2(
+      vm.consignor,
+      vm.consignorId,
       vm.previousDocuments,
       vm.supportingDocuments
     )
@@ -35,6 +37,7 @@
     )
 
     @row_5(
+      vm.departureTransportMeans,
       vm.commodityCode,
       vm.netMass
     )

--- a/app/services/P5/DepartureMessageP5Service.scala
+++ b/app/services/P5/DepartureMessageP5Service.scala
@@ -20,6 +20,7 @@ import connectors.DepartureMovementP5Connector
 import generated.p5.CC015CType
 import generated.p5.CC029CType
 import models.P5.departure.DepartureMessageType.DepartureNotification
+import refactor.viewmodels.p5.RichCC029CType
 import scalaxb.XMLFormat
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -33,7 +34,7 @@ class DepartureMessageP5Service @Inject() (connector: DepartureMovementP5Connect
     departureId: String,
     messageId: String
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[CC029CType] =
-    getMessage[CC029CType](departureId, messageId)
+    getMessage[CC029CType](departureId, messageId).map(_.rollDown)
 
   def getDeclarationData(
     departureId: String,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.librarymanagement.InclExclRule
 
 object AppDependencies {
 
-  private val bootstrapVersion = "8.4.0"
+  private val bootstrapVersion = "8.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion,
@@ -11,7 +11,8 @@ object AppDependencies {
     "org.apache.xmlgraphics"  %  "fop"                        % "2.9",
     "net.sf.barcode4j"        %  "barcode4j"                  % "2.1",
     "net.sf.barcode4j"        %  "barcode4j-fop-ext"          % "2.1",
-    "xerces"                  %  "xercesImpl"                 % "2.12.2"
+    "xerces"                  %  "xercesImpl"                 % "2.12.2",
+    "javax.xml.bind"          %  "jaxb-api"                   % "2.3.1"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,11 +4,11 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.16.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.4.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 

--- a/test/refactor/viewmodels/DummyData.scala
+++ b/test/refactor/viewmodels/DummyData.scala
@@ -451,6 +451,9 @@ trait DummyData extends ScalaxbModelGenerators {
             ConsignmentItemType03(
               goodsItemNumber = "1",
               declarationGoodsItemNumber = BigInt(1),
+              countryOfDispatch = Some("c of dispatch"),
+              countryOfDestination = Some("c of destination"),
+              referenceNumberUCR = Some("ucr"),
               Packaging = Seq(
                 PackagingType02(
                   sequenceNumber = "1",
@@ -490,11 +493,19 @@ trait DummyData extends ScalaxbModelGenerators {
                     netMass = Some(BigDecimal(100))
                   )
                 )
+              ),
+              TransportCharges = Some(
+                TransportChargesType(
+                  methodOfPayment = "mop"
+                )
               )
             ),
             ConsignmentItemType03(
               goodsItemNumber = "2",
               declarationGoodsItemNumber = BigInt(2),
+              countryOfDispatch = Some("c of dispatch"),
+              countryOfDestination = Some("c of destination"),
+              referenceNumberUCR = Some("ucr"),
               Packaging = Seq(
                 PackagingType02(
                   sequenceNumber = "1",
@@ -533,6 +544,11 @@ trait DummyData extends ScalaxbModelGenerators {
                     grossMass = BigDecimal(200),
                     netMass = Some(BigDecimal(100))
                   )
+                )
+              ),
+              TransportCharges = Some(
+                TransportChargesType(
+                  methodOfPayment = "mop"
                 )
               )
             )

--- a/test/refactor/viewmodels/DummyData.scala
+++ b/test/refactor/viewmodels/DummyData.scala
@@ -729,6 +729,71 @@ trait DummyData extends ScalaxbModelGenerators {
     )
   )
 
+  lazy val houseConsignmentType03: HouseConsignmentType03 = HouseConsignmentType03(
+    sequenceNumber = "1",
+    countryOfDispatch = None,
+    grossMass = BigDecimal(1),
+    referenceNumberUCR = None,
+    securityIndicatorFromExportDeclaration = None,
+    Consignor = Some(
+      ConsignorType04(
+        identificationNumber = Some("hc consignor in"),
+        name = Some("hc consignor name"),
+        Address = Some(
+          AddressType07(
+            streetAndNumber = "san",
+            postcode = Some("pc"),
+            city = "city",
+            country = "country"
+          )
+        ),
+        ContactPerson = Some(
+          ContactPersonType01(
+            name = "cp",
+            phoneNumber = "cptel",
+            eMailAddress = Some("cpemail")
+          )
+        )
+      )
+    ),
+    Consignee = Some(
+      ConsigneeType04(
+        identificationNumber = Some("hc consignee in"),
+        name = Some("hc consignee name"),
+        Address = Some(
+          AddressType07(
+            streetAndNumber = "san",
+            postcode = Some("pc"),
+            city = "city",
+            country = "country"
+          )
+        )
+      )
+    ),
+    AdditionalSupplyChainActor = Nil,
+    DepartureTransportMeans = Seq(
+      DepartureTransportMeansType02(
+        sequenceNumber = "1",
+        typeOfIdentification = "toi1",
+        identificationNumber = "in1",
+        nationality = "nat1"
+      ),
+      DepartureTransportMeansType02(
+        sequenceNumber = "2",
+        typeOfIdentification = "toi2",
+        identificationNumber = "in2",
+        nationality = "nat2"
+      )
+    ),
+    PreviousDocument = Nil,
+    SupportingDocument = Nil,
+    TransportDocument = Nil,
+    AdditionalReference = Nil,
+    AdditionalInformation = Nil,
+    TransportCharges = None,
+    ConsignmentItem = Nil
+  )
+
   lazy val consignmentItemType03: ConsignmentItemType03 = ConsignmentItemType03(
     goodsItemNumber = "gin",
     declarationGoodsItemNumber = BigInt(1),

--- a/test/refactor/viewmodels/p5/RichSpec.scala
+++ b/test/refactor/viewmodels/p5/RichSpec.scala
@@ -30,8 +30,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       "when transport charges defined at consignment level" in {
         forAll(arbitrary[TransportChargesType]) {
           transportCharges =>
-            val data = cc029c.copy(Consignment = cc029c.Consignment.copy(TransportCharges = Some(transportCharges)))
-            data.consignmentItems.foreach {
+            val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(TransportCharges = Some(transportCharges)))
+            val result = data.rollDown
+            result.consignmentItems.foreach {
               _.TransportCharges.value mustBe transportCharges
             }
         }
@@ -40,8 +41,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       "when UCR defined at consignment level" in {
         forAll(nonEmptyString) {
           referenceNumberUCR =>
-            val data = cc029c.copy(Consignment = cc029c.Consignment.copy(referenceNumberUCR = Some(referenceNumberUCR)))
-            data.consignmentItems.foreach {
+            val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(referenceNumberUCR = Some(referenceNumberUCR)))
+            val result = data.rollDown
+            result.consignmentItems.foreach {
               _.referenceNumberUCR.value mustBe referenceNumberUCR
             }
         }
@@ -50,8 +52,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       "when country of dispatch defined at consignment level" in {
         forAll(nonEmptyString) {
           countryOfDispatch =>
-            val data = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDispatch = Some(countryOfDispatch)))
-            data.consignmentItems.foreach {
+            val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDispatch = Some(countryOfDispatch)))
+            val result = data.rollDown
+            result.consignmentItems.foreach {
               _.countryOfDispatch.value mustBe countryOfDispatch
             }
         }
@@ -60,8 +63,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       "when country of destination defined at consignment level" in {
         forAll(nonEmptyString) {
           countryOfDestination =>
-            val data = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDestination = Some(countryOfDestination)))
-            data.consignmentItems.foreach {
+            val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDestination = Some(countryOfDestination)))
+            val result = data.rollDown
+            result.consignmentItems.foreach {
               _.countryOfDestination.value mustBe countryOfDestination
             }
         }
@@ -70,8 +74,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
 
     "must not roll down" - {
       "when transport charges undefined at consignment level" in {
-        val data = cc029c.copy(Consignment = cc029c.Consignment.copy(TransportCharges = None))
-        data.consignmentItems.zipWithIndex.foreach {
+        val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(TransportCharges = None))
+        val result = data.rollDown
+        result.consignmentItems.zipWithIndex.foreach {
           case (ci, i) =>
             ci.TransportCharges mustBe
               cc029c.Consignment.HouseConsignment.flatMap(_.ConsignmentItem).apply(i).TransportCharges
@@ -79,8 +84,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       }
 
       "when UCR undefined at consignment level" in {
-        val data = cc029c.copy(Consignment = cc029c.Consignment.copy(referenceNumberUCR = None))
-        data.consignmentItems.zipWithIndex.foreach {
+        val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(referenceNumberUCR = None))
+        val result = data.rollDown
+        result.consignmentItems.zipWithIndex.foreach {
           case (ci, i) =>
             ci.referenceNumberUCR mustBe
               cc029c.Consignment.HouseConsignment.flatMap(_.ConsignmentItem).apply(i).referenceNumberUCR
@@ -88,8 +94,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       }
 
       "when country of dispatch undefined at consignment level" in {
-        val data = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDispatch = None))
-        data.consignmentItems.zipWithIndex.foreach {
+        val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDispatch = None))
+        val result = data.rollDown
+        result.consignmentItems.zipWithIndex.foreach {
           case (ci, i) =>
             ci.countryOfDispatch mustBe
               cc029c.Consignment.HouseConsignment.flatMap(_.ConsignmentItem).apply(i).countryOfDispatch
@@ -97,8 +104,9 @@ class RichSpec extends SpecBase with DummyData with ScalaCheckPropertyChecks wit
       }
 
       "when country of destination undefined at consignment level" in {
-        val data = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDestination = None))
-        data.consignmentItems.zipWithIndex.foreach {
+        val data   = cc029c.copy(Consignment = cc029c.Consignment.copy(countryOfDestination = None))
+        val result = data.rollDown
+        result.consignmentItems.zipWithIndex.foreach {
           case (ci, i) =>
             ci.countryOfDestination mustBe
               cc029c.Consignment.HouseConsignment.flatMap(_.ConsignmentItem).apply(i).countryOfDestination

--- a/test/refactor/viewmodels/p5/tad/ConsignmentItemViewModelSpec.scala
+++ b/test/refactor/viewmodels/p5/tad/ConsignmentItemViewModelSpec.scala
@@ -23,7 +23,7 @@ class ConsignmentItemViewModelSpec extends SpecBase with DummyData {
 
   "must map data to view model" - {
 
-    val result = ConsignmentItemViewModel(consignmentItemType03)
+    val result = ConsignmentItemViewModel(houseConsignmentType03, consignmentItemType03)
 
     "declarationGoodsItemNumber" in {
       result.declarationGoodsItemNumber mustBe "1"
@@ -50,11 +50,19 @@ class ConsignmentItemViewModelSpec extends SpecBase with DummyData {
     }
 
     "consignee" in {
-      result.consignee mustBe "name, san, pc, city, country"
+      result.consignee mustBe "hc consignee name, san, pc, city, country"
     }
 
     "consigneeId" in {
-      result.consigneeId mustBe "in"
+      result.consigneeId mustBe "hc consignee in"
+    }
+
+    "consignor" in {
+      result.consignor mustBe "hc consignor name, san, pc, city, country, cp, cptel, cpemail"
+    }
+
+    "consignorId" in {
+      result.consignorId mustBe "hc consignor in"
     }
 
     "additionalReferences" in {
@@ -83,6 +91,10 @@ class ConsignmentItemViewModelSpec extends SpecBase with DummyData {
 
     "grossMass" in {
       result.grossMass mustBe "200.0"
+    }
+
+    "departureTransportMeans" in {
+      result.departureTransportMeans mustBe "toi1, in1, nat1; toi2, in2, nat2"
     }
 
     "commodityCode" in {


### PR DESCRIPTION
Consignor and departure transport means appear to have gone missing from TLOI in this commit - https://github.com/hmrc/transit-movements-trader-manage-documents/commit/25371897463efbe38e82634981319c6ddc6038f0

This PR adds these back in, and pulls them both along with the consignee from the house consignment level as required.

![Screenshot 2024-03-21 at 14 54 14](https://github.com/hmrc/transit-movements-trader-manage-documents/assets/43777106/09e959f3-5dd6-4418-94dd-ccea6fd50a1b)
