### PR TITLE
content updates - PDF

### DIFF
--- a/app/refactor/views/p5/unloadingpermission/components/items/item.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/items/item.scala.xml
@@ -23,25 +23,25 @@
     <fo:table-row height="12mm" display-align="before" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Decl.good.Nr.</fo:inline> [1111]
+                <fo:inline font-size="7">Decl.good.Nr.</fo:inline> [1111]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.declarationGoodsItemNumber
             </fo:block>
         </fo:table-cell>
         <fo:table-cell number-columns-spanned="2" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Goodit.Nr.</fo:inline> [1102]
+                <fo:inline font-size="7">Goodit.Nr.</fo:inline> [1102]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.goodsItemNumber
             </fo:block>
         </fo:table-cell>
         <fo:table-cell padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Type and number of packages, shipping marks</fo:inline> [1806]
+                <fo:inline font-size="7">Type and number of packages, shipping marks</fo:inline> [1806]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.packaging
             </fo:block>
         </fo:table-cell>
@@ -52,12 +52,12 @@
     <fo:table-row height="8mm" display-align="center" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell number-columns-spanned="2" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Consignee</fo:inline> [1303] @vm.consignee
+                <fo:inline font-size="7">Consignee </fo:inline><fo:inline font-weight="bold" font-size="6">[1303] @vm.consignee</fo:inline>
             </fo:block>
         </fo:table-cell>
         <fo:table-cell number-columns-spanned="2" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">ID</fo:inline> @vm.consigneeId
+                <fo:inline font-size="7">ID </fo:inline><fo:inline font-weight="bold" font-size="6">@vm.consigneeId</fo:inline>
             </fo:block>
         </fo:table-cell>
     </fo:table-row>
@@ -74,17 +74,17 @@
                         <fo:table-row height="12mm">
                             <fo:table-cell padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">UDNG</fo:inline> [1807]
+                                    <fo:inline font-size="7">UDNG</fo:inline> [1807]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.udng
                                 </fo:block>
                             </fo:table-cell>
                             <fo:table-cell padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">CUS code</fo:inline> [1808]
+                                    <fo:inline font-size="7">CUS code</fo:inline> [1808]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.cusCode
                                 </fo:block>
                             </fo:table-cell>
@@ -92,9 +92,9 @@
                         <fo:table-row height="10mm">
                             <fo:table-cell number-columns-spanned="2" padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">Description of goods</fo:inline> [1805]
+                                    <fo:inline font-size="7">Description of goods</fo:inline> [1805]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.descriptionOfGoods
                                 </fo:block>
                             </fo:table-cell>
@@ -110,9 +110,9 @@
     <fo:table-row height="9mm" display-align="center" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell number-columns-spanned="4" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Previous document</fo:inline> [1201]
+                <fo:inline font-size="7">Previous document</fo:inline> [1201]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.previousDocuments
             </fo:block>
         </fo:table-cell>
@@ -123,9 +123,9 @@
     <fo:table-row height="9mm" display-align="center" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell number-columns-spanned="4" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Supporting document</fo:inline> [1203]
+                <fo:inline font-size="7">Supporting document</fo:inline> [1203]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.supportingDocuments
             </fo:block>
         </fo:table-cell>
@@ -136,9 +136,9 @@
     <fo:table-row height="9mm" display-align="center" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell number-columns-spanned="4" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Additional reference</fo:inline> [1204]
+                <fo:inline font-size="7">Additional reference</fo:inline> [1204]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.additionalReferences
             </fo:block>
         </fo:table-cell>
@@ -149,9 +149,9 @@
     <fo:table-row height="9mm" display-align="center" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell number-columns-spanned="4" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Additional information</fo:inline> [1202]
+                <fo:inline font-size="7">Additional information</fo:inline> [1202]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.additionalInformation
             </fo:block>
         </fo:table-cell>
@@ -162,9 +162,9 @@
     <fo:table-row height="9mm" display-align="center" border-style="solid" border-width="1pt" border-color="black">
         <fo:table-cell number-columns-spanned="4" padding-left="2mm">
             <fo:block>
-                <fo:inline font-weight="bold">Transport document</fo:inline> [1205]
+                <fo:inline font-size="7">Transport document</fo:inline> [1205]
             </fo:block>
-            <fo:block>
+            <fo:block font-weight="bold" font-size="6">
                 @vm.transportDocuments
             </fo:block>
         </fo:table-cell>
@@ -182,17 +182,17 @@
                         <fo:table-row height="10mm">
                             <fo:table-cell padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">Commodity code</fo:inline> [1809]
+                                    <fo:inline font-size="7">Commodity code</fo:inline> [1809]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.commodityCode
                                 </fo:block>
                             </fo:table-cell>
                             <fo:table-cell padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">Gross mass</fo:inline> [1804]
+                                    <fo:inline font-size="7">Gross mass</fo:inline> [1804]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.grossMass
                                 </fo:block>
                             </fo:table-cell>
@@ -200,17 +200,17 @@
                         <fo:table-row height="10mm">
                             <fo:table-cell padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">C.of dest</fo:inline> [1607]
+                                    <fo:inline font-size="7">C.of dest</fo:inline> [1607]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.cOfDest
                                 </fo:block>
                             </fo:table-cell>
                             <fo:table-cell padding-left="2mm">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">Net mass</fo:inline> [1801]
+                                    <fo:inline font-size="7">Net mass</fo:inline> [1801]
                                 </fo:block>
-                                <fo:block>
+                                <fo:block font-weight="bold" font-size="6">
                                     @vm.netMass
                                 </fo:block>
                             </fo:table-cell>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_1.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_1.scala.xml
@@ -5,7 +5,7 @@
     <fo:block/>
   </fo:table-cell>
   <fo:table-cell number-columns-spanned="2">
-    <fo:block font-weight="bold" font-size="8pt">EUROPEAN UNION</fo:block>
+    <fo:block font-weight="bold" font-size="8pt">European Union</fo:block>
   </fo:table-cell>
   <fo:table-cell number-columns-spanned="5" number-rows-spanned="1" padding-left="35mm" border-left-width="1pt" border-left-color="black">
       <fo:block font-size="8" font-weight="bold">MRN <fo:inline font-weight="normal">@(mrn)</fo:inline></fo:block>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_2.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_2.scala.xml
@@ -34,11 +34,11 @@
                                   border-top-color="black" margin-left="0.5mm">
                         <fo:table-cell>
                             <fo:block-container margin-top = "0.8mm">
-                                <fo:block font-size="6" font-weight = "bold"><fo:block font-size="8" font-weight = "normal">Declaration Type</fo:block>@(declarationType)</fo:block>
+                                <fo:block font-weight="bold" font-size="6"><fo:block font-size="8" font-weight = "normal">Declaration Type</fo:block>@(declarationType)</fo:block>
                             </fo:block-container>
 
                             <fo:block-container margin-top = "5mm">
-                                <fo:block font-size="8"><fo:block font-size="8" font-weight = "normal">Gross Weight</fo:block>@(totalGrossMass)</fo:block>
+                                <fo:block font-weight="bold" font-size="6"><fo:block font-size="8" font-weight = "normal">Gross Weight</fo:block>@(totalGrossMass)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_3.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_3.scala.xml
@@ -32,7 +32,7 @@
                 inline-progression-dimension.optimum="94mm"
                 margin-bottom = "4mm"
         >
-        <fo:block hyphenate="true">UNLOADING PERMISSIONS - ACCOMPANYING DOCUMENT</fo:block>
+        <fo:block hyphenate="true">Unloading permission - Accompanying document</fo:block>
     </fo:block-container >
         <fo:block-container height = "8mm">
         <fo:block font-size="8pt"
@@ -72,7 +72,7 @@
                                 <fo:table-cell >
                                     <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                         <fo:block>
-                                            <fo:inline>DEPARTURE MEANS OF TRANSPORT @(departureMeansIndex + 1)</fo:inline>
+                                            <fo:inline>Departure means of transport @(departureMeansIndex + 1)</fo:inline>
                                         </fo:block>
 
                                     </fo:block-container>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_3.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_3.scala.xml
@@ -25,7 +25,7 @@
     >
 
         <fo:block-container
-                font-family="sans-serif" font-size="6"
+                font-family="Arial" font-size="6"
                 reference-orientation="90" display-align="center"
                 inline-progression-dimension.minimum="8mm"
                 inline-progression-dimension.maximum="auto"
@@ -72,7 +72,7 @@
                                 <fo:table-cell >
                                     <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                         <fo:block>
-                                            <fo:inline>Departure means of transport @(departureMeansIndex + 1)</fo:inline>
+                                            <fo:inline font-size="8">Departure means of transport @(departureMeansIndex + 1)</fo:inline>
                                         </fo:block>
 
                                     </fo:block-container>
@@ -83,27 +83,27 @@
                             <fo:table-row height="8mm" border-bottom-style="dotted" border-bottom-width="1pt" border-bottom-color="black" margin-left="0.5mm" >
                                 <fo:table-cell  display-align="after"  number-columns-spanned="1">
                                     <fo:block-container overflow="hidden" margin-bottom = "0.8mm">
-                                        <fo:block>
+                                        <fo:block font-size="7">
                                             Identification type
-                                            <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(transportMeans.typeOfIdentification)</fo:block>
+                                            <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(transportMeans.typeOfIdentification)</fo:block>
                                         </fo:block>
                                     </fo:block-container>
                                 </fo:table-cell>
 
                                 <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                                     <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                        <fo:block>
+                                        <fo:block font-size="7">
                                             Identification
-                                            <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(transportMeans.identificationNumber)</fo:block>
+                                            <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(transportMeans.identificationNumber)</fo:block>
                                         </fo:block>
                                     </fo:block-container>
                                 </fo:table-cell>
 
                                 <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                                     <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                        <fo:block>
+                                        <fo:block font-size="7">
                                             Registered country
-                                            <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(transportMeans.nationality)</fo:block>
+                                            <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(transportMeans.nationality)</fo:block>
                                         </fo:block>
                                     </fo:block-container>
                                 </fo:table-cell>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_4.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_4.scala.xml
@@ -37,14 +37,14 @@
                     <fo:table-row height="3mm">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">Supporting document</fo:inline> [1203]</fo:block>
+                                <fo:block><fo:inline font-size="7">Supporting document</fo:inline> [1203]</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
                     <fo:table-row height="7mm" border-bottom-style="solid" border-bottom-width="1pt" border-bottom-color="black">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block>@(supportingDocument)</fo:block>
+                                <fo:block font-weight="bold" font-size="6">@(supportingDocument)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -54,14 +54,14 @@
                     <fo:table-row height="3mm">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">Additional reference</fo:inline> [1204]</fo:block>
+                                <fo:block><fo:inline font-size="7">Additional reference</fo:inline> [1204]</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
                     <fo:table-row height="7mm" border-bottom-style="solid" border-bottom-width="1pt" border-bottom-color="black">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block>@(additionalReference)</fo:block>
+                                <fo:block font-weight="bold" font-size="6">@(additionalReference)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -71,14 +71,14 @@
                     <fo:table-row height="3mm">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">Additional information </fo:inline> [1202]</fo:block>
+                                <fo:block><fo:inline font-size="7">Additional information </fo:inline> [1202]</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
                     <fo:table-row height="7mm" border-bottom-style="solid" border-bottom-width="1pt" border-bottom-color="black">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block>@(additionalInformation)</fo:block>
+                                <fo:block font-weight="bold" font-size="6">@(additionalInformation)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -88,14 +88,14 @@
                     <fo:table-row height="3mm">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">Customs office of destination</fo:inline> [1705]</fo:block>
+                                <fo:block><fo:inline font-size="7">Customs office of destination</fo:inline> [1705]</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
                     <fo:table-row height="7mm" border-bottom-style="solid" border-bottom-width="1pt" border-bottom-color="black">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block>@(customsOfficeOfDestination)</fo:block>
+                                <fo:block font-weight="bold" font-size="6">@(customsOfficeOfDestination)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -105,14 +105,14 @@
                     <fo:table-row height="3mm">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">Country of destination</fo:inline> [1607]</fo:block>
+                                <fo:block><fo:inline font-size="7">Country of destination</fo:inline> [1607]</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
                     <fo:table-row height="7mm" border-bottom-style="solid" border-bottom-width="1pt" border-bottom-color="black">
                         <fo:table-cell  margin-left="0.5mm">
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block>@(countryOfDestination)</fo:block>
+                                <fo:block font-weight="bold" font-size="6">@(countryOfDestination)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_5.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_5.scala.xml
@@ -129,7 +129,7 @@
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
                                 <fo:block>
-                                    Declaration goods item number
+                                    Declaration goods number
                                     <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.declarationGoodsItemNumber)</fo:block>
                                 </fo:block>
                             </fo:block-container>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_5.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_5.scala.xml
@@ -35,7 +35,7 @@
                     <fo:table-row height="5mm">
                         <fo:table-cell  margin-left="0.5mm" >
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">House consignment</fo:inline> @(houseIndex + 1)</fo:block>
+                                <fo:block><fo:inline font-size="8">House consignment</fo:inline> @(houseIndex + 1)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -44,12 +44,12 @@
                         <fo:table-cell  number-columns-spanned="2"   >
                             <fo:block-container overflow="hidden">
                                 <fo:block>
-                                    <fo:inline font-weight="bold">Gross weight</fo:inline>
+                                    <fo:inline font-size="7">Gross weight</fo:inline>
 
                                 </fo:block>
                             </fo:block-container>
                             <fo:block-container height="4%" overflow="hidden">
-                                <fo:block>@(house.grossMass)</fo:block>
+                                <fo:block font-size="6" font-weight="bold">@(house.grossMass)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -63,7 +63,7 @@
                                 <fo:table-cell padding-top = "2mm">
                                     <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                         <fo:block>
-                                            <fo:inline>Departure means of transport @(departureMeansIndex +1)</fo:inline>
+                                            <fo:inline font-size="8">Departure means of transport @(departureMeansIndex +1)</fo:inline>
                                         </fo:block>
 
                                     </fo:block-container>
@@ -74,27 +74,27 @@
                     <fo:table-row height="8mm" border-bottom-style="dotted" border-bottom-width="1pt" border-bottom-color="black" margin-left="0.5mm" >
                         <fo:table-cell  display-align="after"  number-columns-spanned="1">
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm">
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Identification type
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(transportMeans.typeOfIdentification)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(transportMeans.typeOfIdentification)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Identification
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(transportMeans.identificationNumber)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(transportMeans.identificationNumber)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Registered country
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(transportMeans.nationality)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(transportMeans.nationality)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
@@ -108,7 +108,7 @@
                                 <fo:table-cell padding-top="2mm" >
                                     <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                         <fo:block>
-                                            <fo:inline>Item @(itemIndex +1)</fo:inline>
+                                            <fo:inline font-size="8">Item @(itemIndex +1)</fo:inline>
                                         </fo:block>
 
                                     </fo:block-container>
@@ -119,18 +119,18 @@
                     <fo:table-row height="8mm" border-bottom-width="1pt" border-bottom-color="black" margin-left="0.5mm" >
                         <fo:table-cell  display-align="after"  number-columns-spanned="1">
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm">
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Goods item number
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.goodsItemNumber)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.goodsItemNumber)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Declaration goods number
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.declarationGoodsItemNumber)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.declarationGoodsItemNumber)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
@@ -140,18 +140,18 @@
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Combined nomenclature code
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.Commodity.CommodityCode.map(_.harmonizedSystemSubHeadingCode).getOrElse("N/A"))</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.Commodity.CommodityCode.map(_.harmonizedSystemSubHeadingCode).getOrElse("N/A"))</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Commodity code
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.Commodity.CommodityCode.flatMap(_.combinedNomenclatureCode).getOrElse("N/A"))</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.Commodity.CommodityCode.flatMap(_.combinedNomenclatureCode).getOrElse("N/A"))</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
@@ -161,18 +161,18 @@
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Net weight
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.Commodity.GoodsMeasure.flatMap(_.netMass).getOrElse("N/A"))</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.Commodity.GoodsMeasure.flatMap(_.netMass).getOrElse("N/A"))</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Gross weight
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.Commodity.GoodsMeasure.map(_.grossMass).getOrElse("N/A"))</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.Commodity.GoodsMeasure.map(_.grossMass).getOrElse("N/A"))</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
@@ -181,9 +181,9 @@
                     <fo:table-row height="10mm" margin-left="0.5mm" border-bottom-style="dotted" border-bottom-width="1pt" border-bottom-color="black">
                         <fo:table-cell  display-align="after"  number-columns-spanned="3"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Description
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(item.Commodity.descriptionOfGoods)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(item.Commodity.descriptionOfGoods)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
@@ -193,7 +193,7 @@
                         <fo:table-row height="8mm" margin-left="0.5mm">
                             <fo:table-cell padding-top="2mm">
                                 <fo:block-container overflow="hidden" margin-top = "0.8mm" >
-                                    <fo:block>
+                                    <fo:block font-size="8">
                                         <fo:inline>Package @(packageIndex +1)</fo:inline>
                                     </fo:block>
 
@@ -204,27 +204,27 @@
                     <fo:table-row height="8mm" border-bottom-style="dotted" border-bottom-width="1pt" border-bottom-color="black" margin-left="0.5mm" >
                         <fo:table-cell  display-align="after"  number-columns-spanned="1">
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm">
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Type
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(itemPackage.typeOfPackages)</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(itemPackage.typeOfPackages)</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Quantity
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(itemPackage.numberOfPackages.getOrElse("N/A"))</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(itemPackage.numberOfPackages.getOrElse("N/A"))</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
                         <fo:table-cell  display-align="after"  number-columns-spanned="1"   >
                             <fo:block-container overflow="hidden" margin-bottom = "0.8mm" >
-                                <fo:block>
+                                <fo:block font-size="7">
                                     Shipping mark
-                                    <fo:block padding-top="3px" padding-bottom="3px" font-weight="bold">@(itemPackage.shippingMarks.getOrElse("N/A"))</fo:block>
+                                    <fo:block padding-top="3px" padding-bottom="3px" font-size="6" font-weight="bold">@(itemPackage.shippingMarks.getOrElse("N/A"))</fo:block>
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>

--- a/app/refactor/views/p5/unloadingpermission/components/table_1/row_5.scala.xml
+++ b/app/refactor/views/p5/unloadingpermission/components/table_1/row_5.scala.xml
@@ -35,7 +35,7 @@
                     <fo:table-row height="5mm">
                         <fo:table-cell  margin-left="0.5mm" >
                             <fo:block-container overflow="hidden" margin-top = "0.8mm">
-                                <fo:block><fo:inline font-weight="bold">HOUSE CONSIGNMENT</fo:inline> @(houseIndex + 1)</fo:block>
+                                <fo:block><fo:inline font-weight="bold">House consignment</fo:inline> @(houseIndex + 1)</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -63,7 +63,7 @@
                                 <fo:table-cell padding-top = "2mm">
                                     <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                         <fo:block>
-                                            <fo:inline>DEPARTURE MEANS OF TRANSPORT @(departureMeansIndex +1)</fo:inline>
+                                            <fo:inline>Departure means of transport @(departureMeansIndex +1)</fo:inline>
                                         </fo:block>
 
                                     </fo:block-container>
@@ -108,7 +108,7 @@
                                 <fo:table-cell padding-top="2mm" >
                                     <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                         <fo:block>
-                                            <fo:inline>ITEM @(itemIndex +1)</fo:inline>
+                                            <fo:inline>Item @(itemIndex +1)</fo:inline>
                                         </fo:block>
 
                                     </fo:block-container>
@@ -194,7 +194,7 @@
                             <fo:table-cell padding-top="2mm">
                                 <fo:block-container overflow="hidden" margin-top = "0.8mm" >
                                     <fo:block>
-                                        <fo:inline>PACKAGE @(packageIndex +1)</fo:inline>
+                                        <fo:inline>Package @(packageIndex +1)</fo:inline>
                                     </fo:block>
 
                                 </fo:block-container>


### PR DESCRIPTION
Fixing the title cases, font families, weights:

Titles should have `Title case` instead of `UPPER CASE`

Labels - Arial, 8
Sub Labels – Arial, 7
Value - Arial, 6

Nigel confirmed that the titles will have normal weight and values will have bold

[UPD_38VYQTYFU3T0KUTUM3 (25).pdf](https://github.com/hmrc/transit-movements-trader-manage-documents/files/15295402/UPD_38VYQTYFU3T0KUTUM3.25.pdf)
