### PR TITLE
CTCP-5596: DepartureTransportMeans max 3 sequences

### DIFF
--- a/app/refactor/viewmodels/p5/tad/Table1ViewModel.scala
+++ b/app/refactor/viewmodels/p5/tad/Table1ViewModel.scala
@@ -78,7 +78,7 @@ object Table1ViewModel {
       carrierIdentificationNumber = ie029.Consignment.Carrier.map(_.identificationNumber).orElseBlank.take20,
       additionalSupplyChainActorRoles = ie029.Consignment.AdditionalSupplyChainActor.map(_.asString).semiColonSeparate.take30,
       additionalSupplyChainActorIdentificationNumbers = ie029.Consignment.AdditionalSupplyChainActor.map(_.identificationNumber).semiColonSeparate.take20,
-      departureTransportMeans = ie029.Consignment.DepartureTransportMeans.map(_.asString).toBeContinued().take50,
+      departureTransportMeans = ie029.Consignment.DepartureTransportMeans.map(_.asString).take3(_.semiColonSeparate).take50,
       activeBorderTransportMeans = ie029.Consignment.ActiveBorderTransportMeans.map(_.asString).semiColonSeparate.take50,
       activeBorderTransportMeansConveyanceNumbers = ie029.Consignment.ActiveBorderTransportMeans.flatMap(_.conveyanceReferenceNumber).semiColonSeparate,
       placeOfLoading = ie029.Consignment.PlaceOfLoading.map(_.asString).orElseBlank.take20,

--- a/test/refactor/viewmodels/DummyData.scala
+++ b/test/refactor/viewmodels/DummyData.scala
@@ -338,6 +338,18 @@ trait DummyData extends ScalaxbModelGenerators {
           typeOfIdentification = Some("toi2"),
           identificationNumber = Some("in2"),
           nationality = Some("nat2")
+        ),
+        DepartureTransportMeansType02(
+          sequenceNumber = "3",
+          typeOfIdentification = Some("toi3"),
+          identificationNumber = Some("in3"),
+          nationality = Some("nat3")
+        ),
+        DepartureTransportMeansType02(
+          sequenceNumber = "4",
+          typeOfIdentification = Some("toi4"),
+          identificationNumber = Some("in4"),
+          nationality = Some("nat4")
         )
       ),
       CountryOfRoutingOfConsignment = Seq(

--- a/test/refactor/viewmodels/p5/tad/Table1ViewModelSpec.scala
+++ b/test/refactor/viewmodels/p5/tad/Table1ViewModelSpec.scala
@@ -82,7 +82,7 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "departureTransportMeans" in {
-      result.departureTransportMeans mustBe "toi1, in1, nat1..."
+      result.departureTransportMeans mustBe "toi1, in1, nat1; toi2, in2, nat2; toi3, in3, na..."
     }
 
     "activeBorderTransportMeans" in {


### PR DESCRIPTION
[TAD showing 2.pdf](https://github.com/user-attachments/files/16232479/TAD_string.58.pdf)

[TAD showing 3.pdf](https://github.com/user-attachments/files/16232494/TAD_string.59.pdf)

We set a maximum of 50 characters for this box, it is a small field therefore if we had any more characters we would overflow to another line, causing the design of the TAD to be broken. This is fine, as it is agreed we only show what we can. It will depend on how long each field in the data is as to how much is shown

<img width="377" alt="Screenshot 2024-07-15 at 10 25 32" src="https://github.com/user-attachments/assets/c0913950-2d9d-4b3e-ba80-267e92e9bc57">
