### PR TITLE
CTCP-5599/5600/5601: Limit documents to maximum 3 sequences

### DIFF
--- a/app/refactor/viewmodels/p5/tad/Table2ViewModel.scala
+++ b/app/refactor/viewmodels/p5/tad/Table2ViewModel.scala
@@ -38,7 +38,7 @@ object Table2ViewModel {
   def apply(ie029: CC029CType): Table2ViewModel = {
 
     def combine(consignmentLevel: ConsignmentType04 => Seq[String], houseConsignmentLevel: Seq[HouseConsignmentType03] => Seq[String]): String =
-      Seq(consignmentLevel(ie029.Consignment), houseConsignmentLevel(ie029.Consignment.HouseConsignment)).flatten.semiColonSeparate
+      Seq(consignmentLevel(ie029.Consignment), houseConsignmentLevel(ie029.Consignment.HouseConsignment)).flatten.take3(_.semiColonSeparate)
 
     new Table2ViewModel(
       transportEquipment =

--- a/test/refactor/viewmodels/DummyData.scala
+++ b/test/refactor/viewmodels/DummyData.scala
@@ -414,6 +414,18 @@ trait DummyData extends ScalaxbModelGenerators {
           typeValue = "ptv2",
           referenceNumber = "prn2",
           complementOfInformation = Some("pcoi1")
+        ),
+        PreviousDocumentType06(
+          sequenceNumber = "3",
+          typeValue = "ptv3",
+          referenceNumber = "prn3",
+          complementOfInformation = Some("pcoi1")
+        ),
+        PreviousDocumentType06(
+          sequenceNumber = "4",
+          typeValue = "ptv4",
+          referenceNumber = "prn4",
+          complementOfInformation = Some("pcoi1")
         )
       ),
       SupportingDocument = Seq(
@@ -430,6 +442,20 @@ trait DummyData extends ScalaxbModelGenerators {
           referenceNumber = "srn2",
           documentLineItemNumber = Some(BigInt(1)),
           complementOfInformation = Some("scoi1")
+        ),
+        SupportingDocumentType06(
+          sequenceNumber = "3",
+          typeValue = "stv3",
+          referenceNumber = "srn3",
+          documentLineItemNumber = Some(BigInt(1)),
+          complementOfInformation = Some("scoi3")
+        ),
+        SupportingDocumentType06(
+          sequenceNumber = "4",
+          typeValue = "stv4",
+          referenceNumber = "srn4",
+          documentLineItemNumber = Some(BigInt(1)),
+          complementOfInformation = Some("scoi4")
         )
       ),
       TransportDocument = Seq(
@@ -442,6 +468,16 @@ trait DummyData extends ScalaxbModelGenerators {
           sequenceNumber = "2",
           typeValue = "ttv2",
           referenceNumber = "trn2"
+        ),
+        TransportDocumentType02(
+          sequenceNumber = "3",
+          typeValue = "ttv3",
+          referenceNumber = "trn3"
+        ),
+        TransportDocumentType02(
+          sequenceNumber = "4",
+          typeValue = "ttv4",
+          referenceNumber = "trn4"
         )
       ),
       AdditionalReference = Seq(

--- a/test/refactor/viewmodels/p5/tad/Table2ViewModelSpec.scala
+++ b/test/refactor/viewmodels/p5/tad/Table2ViewModelSpec.scala
@@ -152,15 +152,15 @@ class Table2ViewModelSpec extends SpecBase with DummyData {
     }
 
     "previousDocuments" in {
-      result.previousDocuments mustBe "1, ptv1, prn1, pcoi1; 2, ptv2, prn2, pcoi1"
+      result.previousDocuments mustBe "1, ptv1, prn1, pcoi1; 2, ptv2, prn2, pcoi1; 3, ptv3, prn3, pcoi1..."
     }
 
     "transportDocuments" in {
-      result.transportDocuments mustBe "1, ttv1, trn1; 2, ttv2, trn2"
+      result.transportDocuments mustBe "1, ttv1, trn1; 2, ttv2, trn2; 3, ttv3, trn3..."
     }
 
     "supportingDocuments" in {
-      result.supportingDocuments mustBe "1, stv1, srn1, 1, scoi1; 2, stv2, srn2, 1, scoi1"
+      result.supportingDocuments mustBe "1, stv1, srn1, 1, scoi1; 2, stv2, srn2, 1, scoi1; 3, stv3, srn3, 1, scoi3..."
     }
 
     "additionalReferences" in {


### PR DESCRIPTION
All 3 document fields used the same combine method, so was able to complete the tickets in a single change.

[TAD.pdf](https://github.com/user-attachments/files/16236045/TAD_string.69.pdf)

<img width="547" alt="Screenshot 2024-07-15 at 15 22 58" src="https://github.com/user-attachments/assets/4a22753d-7e0d-441e-bfc9-ab0c2bebafa2">
<img width="574" alt="Screenshot 2024-07-15 at 15 23 02" src="https://github.com/user-attachments/assets/1dbd4410-ae5c-4a4a-b107-9f81242de0cb">
