### PR TITLE
CTCP-5677 Fix design for long text

### DIFF
--- a/app/refactor/viewmodels/p5/tad/Table1ViewModel.scala
+++ b/app/refactor/viewmodels/p5/tad/Table1ViewModel.scala
@@ -64,28 +64,29 @@ object Table1ViewModel {
 
     new Table1ViewModel(
       additionalDeclarationType = ie029.TransitOperation.additionalDeclarationType.take10,
-      consignees = consignees.map(_.asString.take200).semiColonSeparate,
-      consigneeIdentificationNumbers = consignees.flatMap(_.identificationNumber.map(_.take20)).semiColonSeparate,
-      consignors = consignors.map(_.asString.take200).semiColonSeparate,
-      consignorIdentificationNumbers = consignors.flatMap(_.identificationNumber.map(_.take20)).semiColonSeparate,
-      consignorContactPersons = consignors.flatMap(_.ContactPerson.map(_.asString.take100)).semiColonSeparate,
+      consignees = consignees.map(_.asString).semiColonSeparate.adjustFor2NarrowLines,
+      consigneeIdentificationNumbers = consignees.flatMap(_.identificationNumber).semiColonSeparate,
+      consignors = consignors.map(_.asString).semiColonSeparate.adjustFor3NarrowLines,
+      consignorIdentificationNumbers = consignors.flatMap(_.identificationNumber).semiColonSeparate,
+      consignorContactPersons = consignors.flatMap(_.ContactPerson.map(_.asString)).semiColonSeparate.adjustFor2NarrowLines,
       declarationType = ie029.TransitOperation.declarationType,
-      holderOfTransitProcedure = ie029.HolderOfTheTransitProcedure.asString,
+      holderOfTransitProcedure = ie029.HolderOfTheTransitProcedure.asString.adjustFor3NarrowLines,
       holderOfTransitProcedureIdentificationNumber = ie029.HolderOfTheTransitProcedure.identificationNumber.orElseBlank,
       representative = ie029.Representative.map(_.asString).orElseBlank,
       representativeIdentificationNumber = ie029.Representative.map(_.identificationNumber).orElseBlank,
       lrn = ie029.TransitOperation.LRN,
       carrierIdentificationNumber = ie029.Consignment.Carrier.map(_.identificationNumber).orElseBlank.take20,
       additionalSupplyChainActorRoles = ie029.Consignment.AdditionalSupplyChainActor.map(_.asString).semiColonSeparate.take30,
-      additionalSupplyChainActorIdentificationNumbers = ie029.Consignment.AdditionalSupplyChainActor.map(_.identificationNumber).semiColonSeparate.take20,
-      departureTransportMeans = ie029.Consignment.DepartureTransportMeans.map(_.asString).take3(_.semiColonSeparate).take50,
-      activeBorderTransportMeans = ie029.Consignment.ActiveBorderTransportMeans.map(_.asString).take3(_.semiColonSeparate).take100,
-      activeBorderTransportMeansConveyanceNumbers = ie029.Consignment.ActiveBorderTransportMeans.flatMap(_.conveyanceReferenceNumber).semiColonSeparate,
-      placeOfLoading = ie029.Consignment.PlaceOfLoading.map(_.asString).orElseBlank.take20,
-      placeOfUnloading = ie029.Consignment.PlaceOfUnloading.map(_.asString).orElseBlank.take20,
+      additionalSupplyChainActorIdentificationNumbers =
+        ie029.Consignment.AdditionalSupplyChainActor.map(_.identificationNumber).semiColonSeparate.adjustFor2NarrowLines,
+      departureTransportMeans = ie029.Consignment.DepartureTransportMeans.map(_.asString).take3(_.semiColonSeparate).adjustFor2WideLines,
+      activeBorderTransportMeans = ie029.Consignment.ActiveBorderTransportMeans.map(_.asString).take3(_.semiColonSeparate).take90,
+      activeBorderTransportMeansConveyanceNumbers = ie029.Consignment.ActiveBorderTransportMeans.flatMap(_.conveyanceReferenceNumber).semiColonSeparate.take45,
+      placeOfLoading = ie029.Consignment.PlaceOfLoading.map(_.asString).orElseBlank.adjustFor2NarrowLines,
+      placeOfUnloading = ie029.Consignment.PlaceOfUnloading.map(_.asString).orElseBlank.adjustFor2NarrowLines,
       modeOfTransportAtBorder = ie029.Consignment.modeOfTransportAtTheBorder.orElseBlank.take20,
       inlandModeOfTransport = ie029.Consignment.inlandModeOfTransport.orElseBlank.take20,
-      locationOfGoods = ie029.Consignment.LocationOfGoods.map(_.asString).orElseBlank.take100,
+      locationOfGoods = ie029.Consignment.LocationOfGoods.map(_.asString).orElseBlank,
       locationOfGoodsContactPerson = ie029.Consignment.LocationOfGoods.flatMap(_.ContactPerson.map(_.asString)).orElseBlank.take100,
       specificCircumstanceIndicator = ie029.TransitOperation.specificCircumstanceIndicator.orElseBlank.take10,
       security = ie029.TransitOperation.security,
@@ -93,7 +94,7 @@ object Table1ViewModel {
       totalGrossMass = ie029.Consignment.grossMass.asString,
       totalItems = ie029.numberOfItems.toString,
       totalPackages = ie029.numberOfPackages.toString(),
-      ucr = ie029.Consignment.referenceNumberUCR.orElseBlank
+      ucr = ie029.Consignment.referenceNumberUCR.orElseBlank.ellipsisAfterMax(30)
     )
   }
 }

--- a/app/refactor/viewmodels/p5/tad/Table2ViewModel.scala
+++ b/app/refactor/viewmodels/p5/tad/Table2ViewModel.scala
@@ -42,7 +42,7 @@ object Table2ViewModel {
       Seq(consignmentLevel(ie029.Consignment), houseConsignmentLevel(ie029.Consignment.HouseConsignment)).flatten.take3(_.semiColonSeparate)
 
     new Table2ViewModel(
-      transportEquipment = ie029.Consignment.TransportEquipment.map(_.asString).semiColonSeparate.take50,
+      transportEquipment = ie029.Consignment.TransportEquipment.map(_.asString).take3(_.semiColonSeparate).adjustFor2WideLines,
       seals = ie029.Consignment.TransportEquipment
         .flatMap(_.Seal)
         .map(
@@ -58,22 +58,22 @@ object Table2ViewModel {
       previousDocuments = combine(
         _.PreviousDocument.map(_.asString),
         _.flatMap(_.PreviousDocument).map(_.asString)
-      ).take100,
+      ).adjustFor2WideLines,
       transportDocuments = combine(
         _.TransportDocument.map(_.asString),
         _.flatMap(_.TransportDocument).map(_.asString)
-      ).take100,
+      ).adjustFor2WideLines,
       supportingDocuments = combine(
         _.SupportingDocument.map(_.asString),
         _.flatMap(_.SupportingDocument).map(_.asString)
-      ).take100,
-      additionalReferences = ie029.Consignment.AdditionalReference.map(_.asString).take3(_.semiColonSeparate),
+      ).adjustFor2WideLines,
+      additionalReferences = ie029.Consignment.AdditionalReference.map(_.asString).take3(_.semiColonSeparate).take90,
       transportCharges = combine(
         _.TransportCharges.map(_.asString).toSeq,
         _.flatMap(_.TransportCharges).map(_.asString)
       ).take20,
-      additionalInformation = ie029.Consignment.AdditionalInformation.map(_.asString).take3(_.semiColonSeparate),
-      guarantees = ie029.Guarantee.map(_.asString).take1,
+      additionalInformation = ie029.Consignment.AdditionalInformation.map(_.asString).take3(_.semiColonSeparate).take90,
+      guarantees = ie029.Guarantee.map(_.asString).take1.adjustFor2WideLines,
       authorisations = ie029.Authorisation.map(_.asString).take3(_.semiColonSeparate)
     )
   }

--- a/app/refactor/viewmodels/package.scala
+++ b/app/refactor/viewmodels/package.scala
@@ -27,18 +27,71 @@ package object viewmodels {
 
   implicit class RichString(value: String) {
 
-    def takeN(n: Int, chars: String = "..."): String =
+    val Ellipsis = "..."
+    // approximate values since we don't use a fixed width font
+    val NarrowLineCharLength             = 45
+    val NarrowLineCharLength_2Lines      = NarrowLineCharLength * 2
+    val NarrowLineCharLength_3Lines      = NarrowLineCharLength * 3
+    val NarrowLineBlankCharLength        = 80 // a line with only spaces need approx. 80 characters
+    val NarrowLineBlankCharLength_2Lines = NarrowLineBlankCharLength * 2
+    val WideLineCharLength               = NarrowLineCharLength * 2
+    val WideLineCharLength_2Lines        = WideLineCharLength * 2
+
+    def takeN(n: Int, chars: String = Ellipsis): String =
       if (value.length > n) {
         value.take(n - 3) + chars
       } else {
         value
       }
 
+    def ellipsisAfterMax(max: Int): String =
+      if (value.length > max) {
+        value.take(max - 3) + Ellipsis
+      } else {
+        value
+      }
+
+    def adjustFor3NarrowLines: String =
+      if (value.length >= NarrowLineCharLength_3Lines) {
+        value.take(NarrowLineCharLength_3Lines - 3) + Ellipsis
+      } else {
+        padTo3rdLine_narrowCell
+      }
+
+    def adjustFor2NarrowLines: String =
+      if (value.length >= NarrowLineCharLength_2Lines) {
+        value.take(NarrowLineCharLength_2Lines - 3) + Ellipsis
+      } else {
+        padTo2ndLine_narrowCell
+      }
+
+    def adjustFor2WideLines: String =
+      if (value.length >= WideLineCharLength_2Lines) {
+        value.take(WideLineCharLength_2Lines - 3) + Ellipsis
+      } else {
+        padTo2ndLine_wideCell
+      }
+
+    def padTo2ndLine_wideCell: String =
+      if (value.length < NarrowLineCharLength_2Lines) value + " " * NarrowLineBlankCharLength_2Lines
+      else value
+
+    def padTo2ndLine_narrowCell: String =
+      if (value.length < NarrowLineCharLength) value + " " * NarrowLineBlankCharLength
+      else value
+
+    def padTo3rdLine_narrowCell: String =
+      if (value.length < NarrowLineCharLength) value + " " * NarrowLineBlankCharLength_2Lines
+      else if (value.length < NarrowLineCharLength_2Lines) value + " " * NarrowLineBlankCharLength
+      else value
+
     def take10: String  = takeN(10)
     def take20: String  = takeN(20)
     def take30: String  = takeN(30)
+    def take45: String  = takeN(45)
     def take50: String  = takeN(50)
     def take60: String  = takeN(60)
+    def take90: String  = takeN(90)
     def take100: String = takeN(100)
     def take200: String = takeN(200)
   }

--- a/app/refactor/views/p5/tad/components/items/row_2.scala.xml
+++ b/app/refactor/views/p5/tad/components/items/row_2.scala.xml
@@ -28,7 +28,9 @@
 
                     <fo:table-row height="6mm">
                         <fo:table-cell margin-left="0.5mm">
-                            <fo:block>@consignor</fo:block>
+                            <fo:block-container white-space="pre" wrap-option="wrap" overflow="hidden">
+                                <fo:block>@consignor</fo:block>
+                            </fo:block-container>
                         </fo:table-cell>
                         <fo:table-cell number-columns-spanned="2" margin-left="0.5mm">
                             <fo:block>@consignorId</fo:block>

--- a/app/refactor/views/p5/tad/components/items/row_3.scala.xml
+++ b/app/refactor/views/p5/tad/components/items/row_3.scala.xml
@@ -68,7 +68,9 @@
 
                     <fo:table-row height="2mm">
                         <fo:table-cell margin-left="0.5mm">
-                            <fo:block>@additionalInformation</fo:block>
+                            <fo:block-container white-space="pre" wrap-option="wrap" overflow="hidden">
+                                <fo:block>@additionalInformation</fo:block>
+                            </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
                 </fo:table-body>

--- a/app/refactor/views/p5/tad/components/table_1/consignee.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_1/consignee.scala.xml
@@ -10,7 +10,7 @@
             <fo:table-body>
                 <fo:table-row height="100%">
                     <fo:table-cell display-align="center" margin-left="0.5%">
-                        <fo:block>Consignee [13 02]</fo:block>
+                        <fo:block>Consignee [13 03]</fo:block>
                     </fo:table-cell>
 
                     <fo:table-cell display-align="center" margin-left="1%">
@@ -23,7 +23,7 @@
 
                     <fo:table-cell margin-left="0.5%">
                         <fo:block-container height="2%" overflow="hidden">
-                            <fo:block>@consignee</fo:block>
+                            <fo:block white-space="pre" wrap-option="wrap">@consignee</fo:block>
                         </fo:block-container>
                     </fo:table-cell>
 

--- a/app/refactor/views/p5/tad/components/table_1/consignor.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_1/consignor.scala.xml
@@ -24,7 +24,7 @@
                 <fo:table-row>
                     <fo:table-cell margin-left="0.5%">
                         <fo:block-container height="2%" overflow="hidden">
-                            <fo:block>@consignor</fo:block>
+                            <fo:block white-space="pre" wrap-option="wrap">@consignor</fo:block>
                         </fo:block-container>
                     </fo:table-cell>
 
@@ -37,14 +37,14 @@
                 </fo:table-row>
 
                 <fo:table-row height="2%">
-                    <fo:table-cell margin-left="0.5%" padding-top="11%">
+                    <fo:table-cell margin-left="0.5%" padding-top="4.2%">
                         <fo:block>
                             Contact person [13 02 074]
                         </fo:block>
                     </fo:table-cell>
 
-                    <fo:table-cell number-columns-spanned="2" margin-left="0.5%" padding-top="11%">
-                        <fo:block-container overflow="hidden">
+                    <fo:table-cell number-columns-spanned="2" margin-left="0.5%" padding-top="4.2%">
+                        <fo:block-container white-space="pre" wrap-option="wrap">
                             <fo:block>@consignorContactPerson</fo:block>
                         </fo:block-container>
                     </fo:table-cell>

--- a/app/refactor/views/p5/tad/components/table_1/holder_of_transit_procedure.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_1/holder_of_transit_procedure.scala.xml
@@ -28,7 +28,7 @@
 
                     <fo:table-cell margin-left="0.5%">
                         <fo:block-container height="2%" overflow="hidden">
-                            <fo:block>@holderOfTransitProcedure</fo:block>
+                            <fo:block white-space="pre" wrap-option="wrap">@holderOfTransitProcedure</fo:block>
                         </fo:block-container>
                     </fo:table-cell>
 
@@ -41,7 +41,7 @@
                 </fo:table-row>
 
                 <fo:table-row height="2%">
-                    <fo:table-cell margin-left="0.5%" padding-top="11%">
+                    <fo:table-cell margin-left="0.5%" padding-top="4.2%" padding-bottom="2%">
                         <fo:block>
                             Contact person [13 02 074]
                         </fo:block>

--- a/app/refactor/views/p5/tad/components/table_1/row_5.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_1/row_5.scala.xml
@@ -91,14 +91,14 @@
                     <fo:table-row>
 
                         <fo:table-cell margin-left="0.5%">
-                            <fo:block-container height="2%" overflow="hidden">
+                            <fo:block-container overflow="hidden">
                                 <fo:block>@additionalSupplyChainActorRoles</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
 
-                        <fo:table-cell margin-left="0.5%" padding-bottom="4%">
-                            <fo:block-container height="2%" overflow="hidden">
-                                <fo:block>@additionalSupplyChainActorIdentificationNumbers
+                        <fo:table-cell margin-left="0.5%" padding-bottom="-0.7%" number-columns-spanned="2">
+                            <fo:block-container>
+                                <fo:block white-space="pre" wrap-option="wrap">@additionalSupplyChainActorIdentificationNumbers
                                 </fo:block>
                             </fo:block-container>
                         </fo:table-cell>
@@ -106,16 +106,16 @@
 
                     <!-- Departure transport means 8% -->
 
-                    <fo:table-row height="2%" border-top-style="solid" border-top-width="1pt" border-top-color="black">
+                    <fo:table-row height="2%" border-top-style="solid" border-top-width="1pt" border-top-color="b;ack">
                         <fo:table-cell display-align="center" margin-left="0.5%">
                             <fo:block>Departure transport means [19 05]</fo:block>
                         </fo:table-cell>
                     </fo:table-row>
 
                     <fo:table-row>
-                        <fo:table-cell margin-left="0.5%" padding-bottom="4%">
+                        <fo:table-cell margin-left="0.5%" padding-bottom="1.55%" number-columns-spanned="3">
                             <fo:block-container height="6%" overflow="hidden">
-                                <fo:block>@departureTransportMeans</fo:block>
+                                <fo:block white-space="pre" wrap-option="wrap">@departureTransportMeans</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -142,8 +142,8 @@
                                 Conveyance reference number [19 02]
                             </fo:block>
                         </fo:table-cell>
-                        <fo:table-cell margin-left="0.5%" padding-top="4%">
-                            <fo:block-container height="2%" overflow="hidden">
+                        <fo:table-cell margin-left="0.5%" padding-top="4%" number-columns-spanned="2">
+                            <fo:block-container height="2%">
                                 <fo:block>@activeBorderTransportMeansConveyanceNumbers
                                 </fo:block>
                             </fo:block-container>
@@ -174,25 +174,26 @@
                                                            border-bottom-style="solid" border-bottom-width="1pt"
                                                            border-bottom-color="black">
                                                 <fo:block>
-                                                    <fo:table width="100%" table-layout="fixed">
-                                                        <fo:table-column/>
-                                                        <fo:table-column/>
+                                                    <fo:table height="60%" width="100%" table-layout="fixed">
+                                                        <fo:table-column column-number="1" column-width="100%"/>
                                                         <fo:table-body>
-                                                            <fo:table-row height="4%">
-                                                                <fo:table-cell number-columns-spanned="1">
-                                                                    <fo:block margin-top="0.5%" margin-left="0.5%">Place
-                                                                        of loading [16 13]
-                                                                    </fo:block>
+                                                            <fo:table-row height="100%">
+                                                                <fo:table-cell display-align="center" margin-left="0.5%">
+                                                                    <fo:block>Place of loading [16 13]</fo:block>
                                                                 </fo:table-cell>
+
                                                             </fo:table-row>
-                                                            <fo:table-row number-columns-spanned="4" height="10%"
-                                                                          padding-bottom="1%">
-                                                                <fo:table-cell margin-left="0.5%">
-                                                                    <fo:block padding-bottom="33%">
-                                                                        @placeOfLoading
-                                                                    </fo:block>
+
+                                                            <fo:table-row>
+
+                                                                <fo:table-cell margin-left="0.5%" padding-bottom="12.5%">
+                                                                    <fo:block-container height="2%" overflow="hidden">
+                                                                        <fo:block white-space="pre" wrap-option="wrap">@placeOfLoading</fo:block>
+                                                                    </fo:block-container>
                                                                 </fo:table-cell>
+
                                                             </fo:table-row>
+
                                                         </fo:table-body>
                                                     </fo:table>
                                                 </fo:block>
@@ -205,25 +206,26 @@
                                                            border-bottom-style="solid" border-bottom-width="1pt"
                                                            border-bottom-color="black">
                                                 <fo:block>
-                                                    <fo:table width="100%" table-layout="fixed">
-                                                        <fo:table-column/>
-                                                        <fo:table-column/>
+                                                    <fo:table height="60%" width="100%" table-layout="fixed">
+                                                        <fo:table-column column-number="1" column-width="100%"/>
                                                         <fo:table-body>
-                                                            <fo:table-row height="4%">
-                                                                <fo:table-cell number-columns-spanned="1">
-                                                                    <fo:block margin-top="0.5%" margin-left="0.5%">Place
-                                                                        of unloading [16 14]
-                                                                    </fo:block>
+                                                            <fo:table-row height="100%">
+                                                                <fo:table-cell display-align="center" margin-left="0.5%">
+                                                                    <fo:block>Place of unloading [16 14]</fo:block>
                                                                 </fo:table-cell>
+
                                                             </fo:table-row>
-                                                            <fo:table-row number-columns-spanned="4" height="20%"
-                                                                          padding-bottom="1%">
-                                                                <fo:table-cell margin-left="0.5%">
-                                                                    <fo:block padding-bottom="33%">
-                                                                        @placeOfUnloading
-                                                                    </fo:block>
+
+                                                            <fo:table-row>
+
+                                                                <fo:table-cell margin-left="0.5%" padding-bottom="12.5%">
+                                                                    <fo:block-container height="2%" overflow="hidden">
+                                                                        <fo:block white-space="pre" wrap-option="wrap">@placeOfUnloading</fo:block>
+                                                                    </fo:block-container>
                                                                 </fo:table-cell>
+
                                                             </fo:table-row>
+
                                                         </fo:table-body>
                                                     </fo:table>
                                                 </fo:block>

--- a/app/refactor/views/p5/tad/components/table_1/row_5.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_1/row_5.scala.xml
@@ -106,7 +106,7 @@
 
                     <!-- Departure transport means 8% -->
 
-                    <fo:table-row height="2%" border-top-style="solid" border-top-width="1pt" border-top-color="b;ack">
+                    <fo:table-row height="2%" border-top-style="solid" border-top-width="1pt" border-top-color="black">
                         <fo:table-cell display-align="center" margin-left="0.5%">
                             <fo:block>Departure transport means [19 05]</fo:block>
                         </fo:table-cell>

--- a/app/refactor/views/p5/tad/components/table_2/row_1.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_2/row_1.scala.xml
@@ -49,7 +49,7 @@
                     </fo:table-row>
 
                     <fo:table-row>
-                        <fo:table-cell margin-left="0.5%" number-columns-spanned="2" padding-bottom="10%">
+                        <fo:table-cell margin-left="0.5%" number-columns-spanned="2" padding-bottom="7%">
                             <fo:block-container height="13.5%" overflow="hidden">
                                 <fo:block>
                                     @transportEquipment

--- a/app/refactor/views/p5/tad/components/table_2/row_2.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_2/row_2.scala.xml
@@ -24,14 +24,14 @@
 
                     <fo:table-row height="2%">
                         <fo:table-cell margin-top="0.5%" display-align="center" margin-left="0.5%">
-                            <fo:block>Previous Document [12 01]</fo:block>adding-bottom="5
+                            <fo:block>Previous Document [12 01]</fo:block>
                         </fo:table-cell>
                     </fo:table-row>
 
                     <fo:table-row>
-                        <fo:table-cell margin-left="0.5%" padding-bottom="10%">
+                        <fo:table-cell margin-left="0.5%" padding-bottom="7.75%">
                             <fo:block-container height="14%" overflow="hidden">
-                                <fo:block>@previousDocuments</fo:block>
+                                <fo:block white-space="pre" wrap-option="wrap">@previousDocuments</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -61,21 +61,21 @@
                                                 <fo:block>
                                                     <fo:table width="100%" table-layout="fixed">
                                                         <fo:table-body>
-                                                            <fo:table-row>
-                                                                <fo:table-cell margin-top="0.5%" display-align="center"
-                                                                               padding-left="1%">
+
+                                                            <fo:table-row height="2%">
+                                                                <fo:table-cell margin-top="0.5%" display-align="center" margin-left="1%">
                                                                     <fo:block>Transport document [12 05]</fo:block>
                                                                 </fo:table-cell>
                                                             </fo:table-row>
+
                                                             <fo:table-row>
-                                                                <fo:table-cell margin-left="0.5%" padding-bottom="10%">
+                                                                <fo:table-cell margin-left="0.5%" padding-bottom="7.75%">
                                                                     <fo:block-container height="14%" overflow="hidden">
-                                                                        <fo:block>
-                                                                            @transportDocuments
-                                                                        </fo:block>
+                                                                        <fo:block white-space="pre" wrap-option="wrap">@transportDocuments</fo:block>
                                                                     </fo:block-container>
                                                                 </fo:table-cell>
                                                             </fo:table-row>
+
                                                         </fo:table-body>
                                                     </fo:table>
                                                 </fo:block>

--- a/app/refactor/views/p5/tad/components/table_2/row_3.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_2/row_3.scala.xml
@@ -31,9 +31,9 @@
                     </fo:table-row>
 
                     <fo:table-row>
-                        <fo:table-cell margin-left="0.5%" padding-bottom="5%">
+                        <fo:table-cell margin-left="0.5%" padding-bottom="0%">
                             <fo:block-container height="14%" overflow="hidden">
-                                <fo:block>@supportingDocuments</fo:block>
+                                <fo:block white-space="pre" wrap-option="wrap">@supportingDocuments</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>
@@ -95,8 +95,8 @@
 
 
                                         <fo:table-row>
-                                            <fo:table-cell margin-left="0.5%">
-                                                <fo:block-container height="6%" overflow="hidden" padding-bottom="5%">
+                                            <fo:table-cell margin-left="0.5%" number-columns-spanned="2">
+                                                <fo:block-container height="6%" overflow="hidden" padding-bottom="2.1%">
                                                     <fo:block>@additionalInformation
                                                     </fo:block>
                                                 </fo:block-container>

--- a/app/refactor/views/p5/tad/components/table_2/row_4.scala.xml
+++ b/app/refactor/views/p5/tad/components/table_2/row_4.scala.xml
@@ -45,10 +45,10 @@
 
                     <fo:table-row>
                         <fo:table-cell>
-                            <fo:block-container height="10%" overflow="hidden" padding-bottom="5%"
+                            <fo:block-container height="10%" overflow="hidden" padding-bottom="2.7%"
                                                 border-bottom-style="solid" border-bottom-width="1pt"
                                                 border-bottom-color="black">
-                                <fo:block margin-left="1%">@guarantees</fo:block>
+                                <fo:block white-space="pre" wrap-option="wrap" margin-left="1%">@guarantees</fo:block>
                             </fo:block-container>
                         </fo:table-cell>
                     </fo:table-row>

--- a/test/refactor/viewmodels/p5/tad/Table1ViewModelSpec.scala
+++ b/test/refactor/viewmodels/p5/tad/Table1ViewModelSpec.scala
@@ -21,6 +21,8 @@ import refactor.viewmodels.DummyData
 
 class Table1ViewModelSpec extends SpecBase with DummyData {
 
+  val lineWithSpaces = " " * 80
+
   "must map data to view model" - {
 
     val result = Table1ViewModel(cc029c)
@@ -30,7 +32,7 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "consignees" in {
-      result.consignees mustBe "name, san, pc, city, country"
+      result.consignees mustBe "name, san, pc, city, country" + lineWithSpaces
     }
 
     "consigneeIdentificationNumbers" in {
@@ -38,7 +40,7 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "consignors" in {
-      result.consignors mustBe "name, san, pc, city, country"
+      result.consignors mustBe "name, san, pc, city, country" + lineWithSpaces * 2
     }
 
     "consignorIdentificationNumbers" in {
@@ -46,7 +48,7 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "consignorContactPersons" in {
-      result.consignorContactPersons mustBe "ccp, ccptel, ccpemail"
+      result.consignorContactPersons mustBe "ccp, ccptel, ccpemail" + lineWithSpaces
     }
 
     "declarationType" in {
@@ -54,7 +56,7 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "holderOfTransitProcedure" in {
-      result.holderOfTransitProcedure mustBe "thin, hn, san, pc, city, country"
+      result.holderOfTransitProcedure mustBe "thin, hn, san, pc, city, country" + lineWithSpaces * 2
     }
 
     "holderOfTransitProcedureIdentificationNumber" in {
@@ -78,11 +80,11 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "additionalSupplyChainActorIdentificationNumbers" in {
-      result.additionalSupplyChainActorIdentificationNumbers mustBe "id1; id2"
+      result.additionalSupplyChainActorIdentificationNumbers mustBe "id1; id2" + lineWithSpaces
     }
 
     "departureTransportMeans" in {
-      result.departureTransportMeans mustBe "toi1, in1, nat1; toi2, in2, nat2; toi3, in3, na..."
+      result.departureTransportMeans mustBe "toi1, in1, nat1; toi2, in2, nat2; toi3, in3, nat3..." + lineWithSpaces * 2
     }
 
     "activeBorderTransportMeans" in {
@@ -94,11 +96,11 @@ class Table1ViewModelSpec extends SpecBase with DummyData {
     }
 
     "placeOfLoading" in {
-      result.placeOfLoading mustBe "polunl, polc, poll"
+      result.placeOfLoading mustBe "polunl, polc, poll" + lineWithSpaces
     }
 
     "placeOfUnloading" in {
-      result.placeOfUnloading mustBe "pouunl, pouc, poul"
+      result.placeOfUnloading mustBe "pouunl, pouc, poul" + lineWithSpaces
     }
 
     "modeOfTransportAtBorder" in {

--- a/test/refactor/viewmodels/p5/tad/Table2ViewModelSpec.scala
+++ b/test/refactor/viewmodels/p5/tad/Table2ViewModelSpec.scala
@@ -24,6 +24,8 @@ import refactor.viewmodels.DummyData
 
 class Table2ViewModelSpec extends SpecBase with DummyData {
 
+  val lineWithSpaces = " " * 160
+
   "must map data to view model" - {
 
     val cc029cP5 = cc029c.copy(Consignment =
@@ -128,7 +130,7 @@ class Table2ViewModelSpec extends SpecBase with DummyData {
     val result = Table2ViewModel(cc029cP5)
 
     "transportEquipment" in {
-      result.transportEquipment mustBe "1, cin1, 2, 1:1; 2, cin2, 3, 2:2; 3, cin3, 3, 3..."
+      result.transportEquipment mustBe "1, cin1, 2, 1:1; 2, cin2, 3, 2:2; 3, cin3, 3, 3:3..." + lineWithSpaces
     }
 
     "seals" in {
@@ -140,15 +142,15 @@ class Table2ViewModelSpec extends SpecBase with DummyData {
     }
 
     "previousDocuments" in {
-      result.previousDocuments mustBe "1, ptv1, prn1, pcoi1; 2, ptv2, prn2, pcoi1; 3, ptv3, prn3, pcoi1..."
+      result.previousDocuments mustBe "1, ptv1, prn1, pcoi1; 2, ptv2, prn2, pcoi1; 3, ptv3, prn3, pcoi1..." + lineWithSpaces
     }
 
     "transportDocuments" in {
-      result.transportDocuments mustBe "1, ttv1, trn1; 2, ttv2, trn2; 3, ttv3, trn3..."
+      result.transportDocuments mustBe "1, ttv1, trn1; 2, ttv2, trn2; 3, ttv3, trn3..." + lineWithSpaces
     }
 
     "supportingDocuments" in {
-      result.supportingDocuments mustBe "1, stv1, srn1, 1, scoi1; 2, stv2, srn2, 1, scoi1; 3, stv3, srn3, 1, scoi3..."
+      result.supportingDocuments mustBe "1, stv1, srn1, 1, scoi1; 2, stv2, srn2, 1, scoi1; 3, stv3, srn3, 1, scoi3..." + lineWithSpaces
     }
 
     "additionalReferences" in {
@@ -164,7 +166,7 @@ class Table2ViewModelSpec extends SpecBase with DummyData {
     }
 
     "guarantees" in {
-      result.guarantees mustBe "1, g1, 1, 1grn1, 1ac1, 11.0, 1c1; 2, 1grn2, 1ac2, 12.0, 1c2..., ogr1..."
+      result.guarantees mustBe "1, g1, 1, 1grn1, 1ac1, 11.0, 1c1; 2, 1grn2, 1ac2, 12.0, 1c2..., ogr1..." + lineWithSpaces
     }
 
     "authorisations" in {


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/CTCP-5523

Previous design assumed that all data would be 1 line and the fixed, hard-coded spacing was calculated based on this assumption. However having some data which overflows into 2nd, 3rd or even more lines broke the design.
Also this led us, in some fields, cutting the data short to avoid breaking the design, although we had enough space to show multiple data items.

Initially I tried some dynamic solutions that could avoid using hard-coded spacing and position the lines accordingly, with wrapping them through the line breaks, using multi lines and using ellipsis (...) if it doesn't fit in the box. This is possible with regular css but Apache Fop has limited capability and it wasn't possible to do this dynamically.

In this solution, I spare 2 or 3 lines for the fields of there is enough space and re-calculated the spacing between the fields based on this. As a result, I had to pad space for short text (adding spaces until it goes to the 2nd or 3rd line), so I can always get 2 or 3 lines for a field even if it is a short or long text.

Another challenge was that we don't have a fixed width font for the pdf we generate. For this reason, I made an approximate calculation about how many letters or spaces fit in 1 line.

For the result, please check the pdfs.
Prior to fix: TAD_brokenPrior.pdf
After fix: TAD_longText.pdf, TAD_shortText.pdf

[TAD_brokenPrior.pdf](https://github.com/user-attachments/files/16468989/TAD_brokenPrior.pdf)
[TAD_longTextpdf.pdf](https://github.com/user-attachments/files/16468990/TAD_longTextpdf.pdf)
[TAD_shortText.pdf](https://github.com/user-attachments/files/16468991/TAD_shortText.pdf)